### PR TITLE
Replaced internal package feed with NuGet.org.

### DIFF
--- a/CoseSignTool/Nuget.config
+++ b/CoseSignTool/Nuget.config
@@ -2,11 +2,8 @@
 <configuration>
     <packageSources>
         <clear />
-        <add key="OSGTools Feed" value="https://microsoft.pkgs.visualstudio.com/_packaging/OSGTools/nuget/v3/index.json" />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </packageSources>
-    <disabledPackageSources>
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    </disabledPackageSources>
     <packageRestore>
         <add key="enabled" value="True" />
         <add key="automatic" value="True" />


### PR DESCRIPTION
The code was using our internal NuGet feed. Replaced internal package feed with NuGet.org.