### PR TITLE
Auto-build and upload on release

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        #language: [ 'csharp' ]
         os: [windows-latest, ubuntu-latest, macOS-latest]
 
     steps:
@@ -34,9 +34,9 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
+        languages: 'csharp'
         queries: security-extended,security-and-quality 
-        # We can append additional queries with a '+' sign. See https://codeql.github.com/codeql-query-help/csharp/ for a list of available C# queries.
+        # See https://codeql.github.com/codeql-query-help/csharp/ for a list of available C# queries.
 
     # Use the Dotnet Build command to load dependencies and build the code.        
     - name: Build debug
@@ -46,4 +46,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:csharp"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 # Build, test, publish, and upload a release of CoseSignTool
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: Pull Request and Continuous Integration Build
+name: Build, Test, and Publish
 on:
   push:
     branches: [ "main" ]
@@ -65,7 +65,7 @@ jobs:
       working-directory: ./published
 
    # List the contents of the published directory to make sure all the artifacts are there.
-    - name: List published directory Windows
+    - name: List published directory
       if: ${{ github.event_name != 'pull_request' }}
       run: ${{ matrix.dir_command }}
       working-directory: ./published
@@ -77,8 +77,8 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ./published/CoseSignTool-*.zip
-        #tag: v0.3.1  # Use hard-coded tags for testing. Otherwise, default to the tag of the release.
         file_glob: true
+        overwrite: true
 
 
 


### PR DESCRIPTION
This PR adds a step in dotnet.yaml to automatically build and upload binaries whenever a new release is created. The binaries are released as zip files.
It also cleans up both dotnet.yaml and CodeQL.yaml to something approaching publication readiness.
