### PR TITLE
DetachedSignatureFactory accepts pre-hashed content as payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## [v0.3.1-pre.11](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.11) (2023-10-11)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v0.3.1-pre.11)
+
+**Merged pull requests:**
+
+- Add password support for certificate files [\#52](https://github.com/microsoft/CoseSignTool/pull/52) ([lemccomb](https://github.com/lemccomb))
+
 ## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0)
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -16,13 +24,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
-
 ## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
+
+## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
 
 **Merged pull requests:**
 

--- a/CoseSign1.Tests/DetachedSignatureFactoryTests.cs
+++ b/CoseSign1.Tests/DetachedSignatureFactoryTests.cs
@@ -3,6 +3,8 @@
 
 namespace CoseSign1.Tests;
 
+using System.Runtime.Intrinsics.Arm;
+
 /// <summary>
 /// Class for Testing Methods of <see cref="DetachedSignatureFactory"/>
 /// </summary>
@@ -75,6 +77,49 @@ public class DetachedSignatureFactoryTests
     }
 
     [Test]
+    public async Task TestCreateDetachedSignatureHashProvidedAsync()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider(nameof(TestCreateDetachedSignatureHashProvidedAsync));
+        using DetachedSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        using HashAlgorithm hasher = CoseSign1MessageDetachedSignatureExtensions.CreateHashAlgorithmFromName(factory.HashAlgorithmName)
+                         ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageDetachedSignatureExtensions.CreateHashAlgorithmFromName)}");
+        byte[] hash = hasher!.ComputeHash(randomBytes);
+        using MemoryStream hashStream = new(hash);
+
+        // test the sync method
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignature(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature = factory.CreateDetachedSignature(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
+
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignature(hashStream, coseSigningKeyProvider, string.Empty));
+        hashStream.Seek(0, SeekOrigin.Begin);
+        CoseSign1Message detachedSignature2 = factory.CreateDetachedSignature(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        detachedSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature2.SignatureMatches(randomBytes).Should().BeTrue();
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+        // test the async methods
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureAsync(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature3 = await factory.CreateDetachedSignatureAsync(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        detachedSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature3.SignatureMatches(randomBytes).Should().BeTrue();
+
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureAsync(hashStream, coseSigningKeyProvider, string.Empty));
+        hashStream.Seek(0, SeekOrigin.Begin);
+        CoseSign1Message detachedSignature4 = await factory.CreateDetachedSignatureAsync(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        detachedSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature4.SignatureMatches(randomBytes).Should().BeTrue();
+        hashStream.Seek(0, SeekOrigin.Begin);
+    }
+
+    [Test]
     public async Task TestCreateDetachedSignatureBytesAsync()
     {
         ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider(nameof(TestCreateDetachedSignatureBytesAsync));
@@ -115,6 +160,49 @@ public class DetachedSignatureFactoryTests
     }
 
     [Test]
+    public async Task TestCreateDetachedSignatureBytesHashProvidedAsync()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider(nameof(TestCreateDetachedSignatureBytesHashProvidedAsync));
+        using DetachedSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        using HashAlgorithm hasher = CoseSign1MessageDetachedSignatureExtensions.CreateHashAlgorithmFromName(factory.HashAlgorithmName)
+                 ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageDetachedSignatureExtensions.CreateHashAlgorithmFromName)}");
+        byte[] hash = hasher!.ComputeHash(randomBytes);
+        using MemoryStream hashStream = new(hash);
+
+        // test the sync method
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureBytes(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytes(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true).ToArray());
+        detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
+
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureBytes(hashStream, coseSigningKeyProvider, string.Empty));
+        hashStream.Seek(0, SeekOrigin.Begin);
+        CoseSign1Message detachedSignature2 = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytes(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true).ToArray());
+        detachedSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature2.SignatureMatches(randomBytes).Should().BeTrue();
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+        // test the async methods
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesAsync(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature3 = CoseMessage.DecodeSign1((await factory.CreateDetachedSignatureBytesAsync(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true)).ToArray());
+        detachedSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        detachedSignature3.SignatureMatches(randomBytes).Should().BeTrue();
+
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesAsync(hashStream, coseSigningKeyProvider, string.Empty));
+        hashStream.Seek(0, SeekOrigin.Begin);
+        CoseSign1Message detachedSignature4 = CoseMessage.DecodeSign1((await factory.CreateDetachedSignatureBytesAsync(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true)).ToArray());
+        detachedSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
+        hashStream.Seek(0, SeekOrigin.Begin);
+        detachedSignature4.SignatureMatches(randomBytes).Should().BeTrue();
+    }
+
+    [Test]
     public void TestCreateDetachedSignatureMd5()
     {
         ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider(nameof(TestCreateDetachedSignatureMd5));
@@ -128,6 +216,29 @@ public class DetachedSignatureFactoryTests
         detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-md5");
         detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
+    }
+
+    [Test]
+    public void TestCreateDetachedSignatureMd5HashProvided()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider(nameof(TestCreateDetachedSignatureMd5));
+        using DetachedSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        using HashAlgorithm hasher = CoseSign1MessageDetachedSignatureExtensions.CreateHashAlgorithmFromName(HashAlgorithmName.MD5)
+         ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageDetachedSignatureExtensions.CreateHashAlgorithmFromName)}");
+        byte[] hash = hasher!.ComputeHash(randomBytes);
+
+        // test the sync method
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignature(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytes(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true).ToArray());
+        detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
+        detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-md5");
+        detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
+
+        // test unknown hash length
+        // test the sync method
+        Assert.Throws<ArgumentException>(() => factory.CreateDetachedSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", payloadHashed: true));
     }
 
     [Test]

--- a/CoseSign1.Tests/DetachedSignatureFactoryTests.cs
+++ b/CoseSign1.Tests/DetachedSignatureFactoryTests.cs
@@ -89,30 +89,30 @@ public class DetachedSignatureFactoryTests
         using MemoryStream hashStream = new(hash);
 
         // test the sync method
-        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignature(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message detachedSignature = factory.CreateDetachedSignature(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureFromHash(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature = factory.CreateDetachedSignatureFromHash(hash, coseSigningKeyProvider, "application/test.payload");
         detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignature(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message detachedSignature2 = factory.CreateDetachedSignature(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        CoseSign1Message detachedSignature2 = factory.CreateDetachedSignatureFromHash(hashStream, coseSigningKeyProvider, "application/test.payload");
         detachedSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature2.SignatureMatches(randomBytes).Should().BeTrue();
         hashStream.Seek(0, SeekOrigin.Begin);
 
         // test the async methods
-        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureAsync(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message detachedSignature3 = await factory.CreateDetachedSignatureAsync(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureFromHashAsync(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature3 = await factory.CreateDetachedSignatureFromHashAsync(hash, coseSigningKeyProvider, "application/test.payload");
         detachedSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature3.SignatureMatches(randomBytes).Should().BeTrue();
 
-        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureAsync(hashStream, coseSigningKeyProvider, string.Empty));
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureFromHashAsync(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message detachedSignature4 = await factory.CreateDetachedSignatureAsync(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true);
+        CoseSign1Message detachedSignature4 = await factory.CreateDetachedSignatureFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload");
         detachedSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature4.SignatureMatches(randomBytes).Should().BeTrue();
@@ -172,30 +172,30 @@ public class DetachedSignatureFactoryTests
         using MemoryStream hashStream = new(hash);
 
         // test the sync method
-        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureBytes(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message detachedSignature = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytes(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true).ToArray());
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesFromHash(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload").ToArray());
         detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
 
-        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureBytes(hashStream, coseSigningKeyProvider, string.Empty));
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesFromHash(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message detachedSignature2 = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytes(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true).ToArray());
+        CoseSign1Message detachedSignature2 = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytesFromHash(hashStream, coseSigningKeyProvider, "application/test.payload").ToArray());
         detachedSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature2.SignatureMatches(randomBytes).Should().BeTrue();
         hashStream.Seek(0, SeekOrigin.Begin);
 
         // test the async methods
-        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesAsync(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message detachedSignature3 = CoseMessage.DecodeSign1((await factory.CreateDetachedSignatureBytesAsync(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true)).ToArray());
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesFromHashAsync(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature3 = CoseMessage.DecodeSign1((await factory.CreateDetachedSignatureBytesFromHashAsync(hash, coseSigningKeyProvider, "application/test.payload")).ToArray());
         detachedSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         detachedSignature3.SignatureMatches(randomBytes).Should().BeTrue();
 
-        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesAsync(hashStream, coseSigningKeyProvider, string.Empty));
+        Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateDetachedSignatureBytesFromHashAsync(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message detachedSignature4 = CoseMessage.DecodeSign1((await factory.CreateDetachedSignatureBytesAsync(hashStream, coseSigningKeyProvider, "application/test.payload", payloadHashed: true)).ToArray());
+        CoseSign1Message detachedSignature4 = CoseMessage.DecodeSign1((await factory.CreateDetachedSignatureBytesFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload")).ToArray());
         detachedSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-sha256");
         hashStream.Seek(0, SeekOrigin.Begin);
@@ -230,15 +230,15 @@ public class DetachedSignatureFactoryTests
         byte[] hash = hasher!.ComputeHash(randomBytes);
 
         // test the sync method
-        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignature(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message detachedSignature = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytes(hash, coseSigningKeyProvider, "application/test.payload", payloadHashed: true).ToArray());
+        Assert.Throws<ArgumentNullException>(() => factory.CreateDetachedSignatureFromHash(hash, coseSigningKeyProvider, string.Empty));
+        CoseSign1Message detachedSignature = CoseMessage.DecodeSign1(factory.CreateDetachedSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload").ToArray());
         detachedSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         detachedSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+hash-md5");
         detachedSignature.SignatureMatches(randomBytes).Should().BeTrue();
 
         // test unknown hash length
         // test the sync method
-        Assert.Throws<ArgumentException>(() => factory.CreateDetachedSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", payloadHashed: true));
+        Assert.Throws<ArgumentException>(() => factory.CreateDetachedSignatureFromHash(randomBytes, coseSigningKeyProvider, "application/test.payload"));
     }
 
     [Test]

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -85,6 +85,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public CoseSign1Message CreateDetachedSignatureFromHash(
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -121,6 +122,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public Task<CoseSign1Message> CreateDetachedSignatureFromHashAsync(
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -157,6 +159,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public CoseSign1Message CreateDetachedSignatureFromHash(
         Stream rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -193,6 +196,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public Task<CoseSign1Message> CreateDetachedSignatureFromHashAsync(
         Stream rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -229,6 +233,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public ReadOnlyMemory<byte> CreateDetachedSignatureBytesFromHash(
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -265,6 +270,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesFromHashAsync(
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -301,6 +307,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public ReadOnlyMemory<byte> CreateDetachedSignatureBytesFromHash(
         Stream rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -337,6 +344,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
     public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesFromHashAsync(
         Stream rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
@@ -356,8 +364,10 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="contentType">The user specified content type.</param>
     /// <param name="streamPayload">If not null, then Stream API's on the CoseSign1MessageFactory are used.</param>
     /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
+    /// <param name="payloadHashed">True if the payload represents the raw hash</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">payloadHashed is set, but hash size does not correspond to any known hash algorithms</exception>
     private object CreateDetachedSignatureWithChecksInternal(
         bool returnBytes,
         ICoseSigningKeyProvider signingKeyProvider,

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -392,7 +392,7 @@ public sealed class DetachedSignatureFactory : IDisposable
                                  : bytePayload!.Value.ToArray();
             try
             {
-                HashAlgorithmName algoName = SizeToAlgorithm[hash.Length];
+                HashAlgorithmName algoName = SizeInBytesToAlgorithm[hash.Length];
                 extendedContentType = ExtendContentType(contentType, algoName);
             }
             catch (KeyNotFoundException e)
@@ -416,9 +416,9 @@ public sealed class DetachedSignatureFactory : IDisposable
     }
 
     /// <summary>
-    /// quick lookup of algorithm name based on hash size
+    /// quick lookup of algorithm name based on size of raw hash in bytes
     /// </summary>
-    private static readonly ConcurrentDictionary<int, HashAlgorithmName> SizeToAlgorithm = new(
+    private static readonly ConcurrentDictionary<int, HashAlgorithmName> SizeInBytesToAlgorithm = new(
         new Dictionary<int, HashAlgorithmName>()
         {
             { 16, HashAlgorithmName.MD5 },
@@ -451,8 +451,9 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// Method which produces a mime type extension based on the given content type and hash algorithm name.
     /// </summary>
     /// <param name="contentType">The content type to append the hash value to if not already appended.</param>
-    /// <returns></returns>
-    private string ExtendContentType(string contentType, HashAlgorithmName algorithmName)
+    /// <param name="algorithmName">The "HashAlgorithmName" to append if not already appended.</param>
+    /// <returns>A string representing the content type with an appended hash algorithm</returns>
+    private static string ExtendContentType(string contentType, HashAlgorithmName algorithmName)
     {
         // extract from the string cache to keep string allocations down.
         string extensionMapping = MimeExtensionMap.GetOrAdd(algorithmName.Name, (name) => $"+hash-{name.ToLowerInvariant()}");

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -427,6 +427,7 @@ public sealed class DetachedSignatureFactory : IDisposable
 
     /// <summary>
     /// quick lookup of algorithm name based on size of raw hash in bytes
+    /// References: https://csrc.nist.gov/projects/hash-functions, https://en.wikipedia.org/wiki/Secure_Hash_Algorithms
     /// </summary>
     private static readonly ConcurrentDictionary<int, HashAlgorithmName> SizeInBytesToAlgorithm = new(
         new Dictionary<int, HashAlgorithmName>()

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -367,6 +367,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// <param name="payloadHashed">True if the payload represents the raw hash</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
     /// <exception cref="ArgumentException">payloadHashed is set, but hash size does not correspond to any known hash algorithms</exception>
     private object CreateDetachedSignatureWithChecksInternal(
         bool returnBytes,

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -71,13 +71,29 @@ public sealed class DetachedSignatureFactory : IDisposable
     public CoseSign1Message CreateDetachedSignature(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+        string contentType) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
                                             returnBytes: false,
                                             signingKeyProvider: signingKeyProvider,
                                             contentType: contentType,
-                                            bytePayload: payload,
-                                            payloadHashed: payloadHashed);
+                                            bytePayload: payload);
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public CoseSign1Message CreateDetachedSignatureFromHash(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: false,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            bytePayload: rawHash,
+                                            payloadHashed: true);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -90,14 +106,31 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<CoseSign1Message> CreateDetachedSignatureAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => Task.FromResult(
-                                            (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
-                                                returnBytes: false,
-                                                signingKeyProvider: signingKeyProvider,
-                                                contentType: contentType,
-                                                bytePayload: payload,
-                                                payloadHashed: payloadHashed));
+        string contentType) => Task.FromResult(
+                                        (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: false,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            bytePayload: payload));
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<CoseSign1Message> CreateDetachedSignatureFromHashAsync(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => Task.FromResult(
+                                        (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: false,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            bytePayload: rawHash,
+                                            payloadHashed: true));
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -110,13 +143,29 @@ public sealed class DetachedSignatureFactory : IDisposable
     public CoseSign1Message CreateDetachedSignature(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+        string contentType) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
                                             returnBytes: false,
                                             signingKeyProvider: signingKeyProvider,
                                             contentType: contentType,
-                                            streamPayload: payload,
-                                            payloadHashed: payloadHashed);
+                                            streamPayload: payload);
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public CoseSign1Message CreateDetachedSignatureFromHash(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: false,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            streamPayload: rawHash,
+                                            payloadHashed: true);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -129,14 +178,31 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<CoseSign1Message> CreateDetachedSignatureAsync(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => Task.FromResult(
-                                            (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
-                                                returnBytes: false,
-                                                signingKeyProvider: signingKeyProvider,
-                                                contentType: contentType,
-                                                streamPayload: payload,
-                                                payloadHashed: payloadHashed));
+        string contentType) => Task.FromResult(
+                                    (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                        returnBytes: false,
+                                        signingKeyProvider: signingKeyProvider,
+                                        contentType: contentType,
+                                        streamPayload: payload));
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<CoseSign1Message> CreateDetachedSignatureFromHashAsync(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => Task.FromResult(
+                                    (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                        returnBytes: false,
+                                        signingKeyProvider: signingKeyProvider,
+                                        contentType: contentType,
+                                        streamPayload: rawHash,
+                                        payloadHashed: true));
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -149,13 +215,29 @@ public sealed class DetachedSignatureFactory : IDisposable
     public ReadOnlyMemory<byte> CreateDetachedSignatureBytes(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+        string contentType) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
                                             returnBytes: true,
                                             signingKeyProvider: signingKeyProvider,
                                             contentType: contentType,
-                                            bytePayload: payload,
-                                            payloadHashed: payloadHashed);
+                                            bytePayload: payload);
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public ReadOnlyMemory<byte> CreateDetachedSignatureBytesFromHash(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: true,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            bytePayload: rawHash,
+                                            payloadHashed: true);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -168,14 +250,31 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => Task.FromResult(
+        string contentType) => Task.FromResult(
                                             (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
                                                 returnBytes: true,
                                                 signingKeyProvider: signingKeyProvider,
                                                 contentType: contentType,
-                                                bytePayload: payload,
-                                                payloadHashed: payloadHashed));
+                                                bytePayload: payload));
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesFromHashAsync(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => Task.FromResult(
+                                            (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                                returnBytes: true,
+                                                signingKeyProvider: signingKeyProvider,
+                                                contentType: contentType,
+                                                bytePayload: rawHash,
+                                                payloadHashed: true));
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -188,13 +287,29 @@ public sealed class DetachedSignatureFactory : IDisposable
     public ReadOnlyMemory<byte> CreateDetachedSignatureBytes(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+        string contentType) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
                                             returnBytes: true,
                                             signingKeyProvider: signingKeyProvider,
                                             contentType: contentType,
-                                            streamPayload: payload,
-                                            payloadHashed: payloadHashed);
+                                            streamPayload: payload);
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public ReadOnlyMemory<byte> CreateDetachedSignatureBytesFromHash(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: true,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            streamPayload: rawHash,
+                                            payloadHashed: true);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -207,14 +322,31 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesAsync(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType,
-        bool payloadHashed = false) => Task.FromResult(
-                                            (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
-                                                returnBytes: true,
-                                                signingKeyProvider: signingKeyProvider,
-                                                contentType: contentType,
-                                                streamPayload: payload,
-                                                payloadHashed: payloadHashed));
+        string contentType) => Task.FromResult(
+                                    (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                        returnBytes: true,
+                                        signingKeyProvider: signingKeyProvider,
+                                        contentType: contentType,
+                                        streamPayload: payload));
+
+    /// <summary>
+    /// Creates a detached signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a detached signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesFromHashAsync(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType) => Task.FromResult(
+                                    (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                        returnBytes: true,
+                                        signingKeyProvider: signingKeyProvider,
+                                        contentType: contentType,
+                                        streamPayload: rawHash,
+                                        payloadHashed: true));
 
     /// <summary>
     /// Does the heavy lifting for this class in computing the hash and creating the correct representation of the CoseSign1Message base on input.

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -71,11 +71,13 @@ public sealed class DetachedSignatureFactory : IDisposable
     public CoseSign1Message CreateDetachedSignature(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: false,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        bytePayload: payload);
+        string contentType,
+        bool payloadHashed = false) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: false,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            bytePayload: payload,
+                                            payloadHashed: payloadHashed);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -88,12 +90,14 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<CoseSign1Message> CreateDetachedSignatureAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => Task.FromResult(
-                                    (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: false,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        bytePayload: payload));
+        string contentType,
+        bool payloadHashed = false) => Task.FromResult(
+                                            (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                                returnBytes: false,
+                                                signingKeyProvider: signingKeyProvider,
+                                                contentType: contentType,
+                                                bytePayload: payload,
+                                                payloadHashed: payloadHashed));
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -106,11 +110,13 @@ public sealed class DetachedSignatureFactory : IDisposable
     public CoseSign1Message CreateDetachedSignature(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: false,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        streamPayload: payload);
+        string contentType,
+        bool payloadHashed = false) => (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: false,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            streamPayload: payload,
+                                            payloadHashed: payloadHashed);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -123,12 +129,14 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<CoseSign1Message> CreateDetachedSignatureAsync(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => Task.FromResult(
-                                    (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: false,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        streamPayload: payload));
+        string contentType,
+        bool payloadHashed = false) => Task.FromResult(
+                                            (CoseSign1Message)CreateDetachedSignatureWithChecksInternal(
+                                                returnBytes: false,
+                                                signingKeyProvider: signingKeyProvider,
+                                                contentType: contentType,
+                                                streamPayload: payload,
+                                                payloadHashed: payloadHashed));
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -141,11 +149,13 @@ public sealed class DetachedSignatureFactory : IDisposable
     public ReadOnlyMemory<byte> CreateDetachedSignatureBytes(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: true,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        bytePayload: payload);
+        string contentType,
+        bool payloadHashed = false) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: true,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            bytePayload: payload,
+                                            payloadHashed: payloadHashed);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -158,12 +168,14 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => Task.FromResult(
-                                    (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: true,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        bytePayload: payload));
+        string contentType,
+        bool payloadHashed = false) => Task.FromResult(
+                                            (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                                returnBytes: true,
+                                                signingKeyProvider: signingKeyProvider,
+                                                contentType: contentType,
+                                                bytePayload: payload,
+                                                payloadHashed: payloadHashed));
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -176,11 +188,13 @@ public sealed class DetachedSignatureFactory : IDisposable
     public ReadOnlyMemory<byte> CreateDetachedSignatureBytes(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: true,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        streamPayload: payload);
+        string contentType,
+        bool payloadHashed = false) => (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                            returnBytes: true,
+                                            signingKeyProvider: signingKeyProvider,
+                                            contentType: contentType,
+                                            streamPayload: payload,
+                                            payloadHashed: payloadHashed);
 
     /// <summary>
     /// Creates a detached signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -193,12 +207,14 @@ public sealed class DetachedSignatureFactory : IDisposable
     public Task<ReadOnlyMemory<byte>> CreateDetachedSignatureBytesAsync(
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType) => Task.FromResult(
-                                    (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
-                                        returnBytes: true,
-                                        signingKeyProvider: signingKeyProvider,
-                                        contentType: contentType,
-                                        streamPayload: payload));
+        string contentType,
+        bool payloadHashed = false) => Task.FromResult(
+                                            (ReadOnlyMemory<byte>)CreateDetachedSignatureWithChecksInternal(
+                                                returnBytes: true,
+                                                signingKeyProvider: signingKeyProvider,
+                                                contentType: contentType,
+                                                streamPayload: payload,
+                                                payloadHashed: payloadHashed));
 
     /// <summary>
     /// Does the heavy lifting for this class in computing the hash and creating the correct representation of the CoseSign1Message base on input.
@@ -215,7 +231,8 @@ public sealed class DetachedSignatureFactory : IDisposable
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
         Stream? streamPayload = null,
-        ReadOnlyMemory<byte>? bytePayload = null)
+        ReadOnlyMemory<byte>? bytePayload = null,
+        bool payloadHashed = false)
     {
         if (string.IsNullOrWhiteSpace(contentType))
         {
@@ -228,21 +245,56 @@ public sealed class DetachedSignatureFactory : IDisposable
             throw new ArgumentNullException("payload", "Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null");
         }
 
-        ReadOnlyMemory<byte> hash = streamPayload != null
-                                    ? InternalHashAlgorithm.ComputeHash(streamPayload)
-                                    : InternalHashAlgorithm.ComputeHash(bytePayload!.Value.ToArray());
+        ReadOnlyMemory<byte> hash;
+        string extendedContentType;
+        if (!payloadHashed)
+        {
+            hash = streamPayload != null
+                                 ? InternalHashAlgorithm.ComputeHash(streamPayload)
+                                 : InternalHashAlgorithm.ComputeHash(bytePayload!.Value.ToArray());
+            extendedContentType = ExtendContentType(contentType);
+        } else
+        {
+            hash = streamPayload != null
+                                 ? streamPayload.GetBytes()
+                                 : bytePayload!.Value.ToArray();
+            try
+            {
+                HashAlgorithmName algoName = SizeToAlgorithm[hash.Length];
+                extendedContentType = ExtendContentType(contentType, algoName);
+            }
+            catch (KeyNotFoundException e)
+            {
+                throw new ArgumentException($"{nameof(payloadHashed)} is set, but payload size does not correspond to any known hash sizes in {nameof(HashAlgorithmName)}", e);
+            }
+        }
+
+
         return returnBytes
                ? InternalMessageFactory.CreateCoseSign1MessageBytes(
                     hash,
                     signingKeyProvider,
                     embedPayload: true,
-                    contentType: ExtendContentType(contentType))
+                    contentType: extendedContentType)
                : InternalMessageFactory.CreateCoseSign1Message(
                     hash,
                     signingKeyProvider,
                     embedPayload: true,
-                    contentType: ExtendContentType(contentType));
+                    contentType: extendedContentType);
     }
+
+    /// <summary>
+    /// quick lookup of algorithm name based on hash size
+    /// </summary>
+    private static readonly ConcurrentDictionary<int, HashAlgorithmName> SizeToAlgorithm = new(
+        new Dictionary<int, HashAlgorithmName>()
+        {
+            { 16, HashAlgorithmName.MD5 },
+            { 20, HashAlgorithmName.SHA1 },
+            { 32, HashAlgorithmName.SHA256 },
+            { 48, HashAlgorithmName.SHA384 },
+            { 64, HashAlgorithmName.SHA512 }
+        });
 
     /// <summary>
     /// quick lookup map between algorithm name and mime extension
@@ -261,10 +313,17 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// </summary>
     /// <param name="contentType">The content type to append the hash value to if not already appended.</param>
     /// <returns></returns>
-    private string ExtendContentType(string contentType)
+    private string ExtendContentType(string contentType) => ExtendContentType(contentType, InternalHashAlgorithmName);
+
+    /// <summary>
+    /// Method which produces a mime type extension based on the given content type and hash algorithm name.
+    /// </summary>
+    /// <param name="contentType">The content type to append the hash value to if not already appended.</param>
+    /// <returns></returns>
+    private string ExtendContentType(string contentType, HashAlgorithmName algorithmName)
     {
         // extract from the string cache to keep string allocations down.
-        string extensionMapping = MimeExtensionMap.GetOrAdd(InternalHashAlgorithmName.Name, (name) => $"+hash-{name.ToLowerInvariant()}");
+        string extensionMapping = MimeExtensionMap.GetOrAdd(algorithmName.Name, (name) => $"+hash-{name.ToLowerInvariant()}");
 
         // only add the extension mapping, if it's not already present within the contentType
         bool alreadyPresent = contentType.IndexOf("+hash-", StringComparison.InvariantCultureIgnoreCase) != -1;

--- a/CoseSign1/DetachedSignatureFactory.cs
+++ b/CoseSign1/DetachedSignatureFactory.cs
@@ -455,7 +455,7 @@ public sealed class DetachedSignatureFactory : IDisposable
     /// Method which produces a mime type extension based on the given content type and hash algorithm name.
     /// </summary>
     /// <param name="contentType">The content type to append the hash value to if not already appended.</param>
-    /// <returns></returns>
+    /// <returns>A string representing the content type with an appended hash algorithm</returns>
     private string ExtendContentType(string contentType) => ExtendContentType(contentType, InternalHashAlgorithmName);
 
     /// <summary>


### PR DESCRIPTION
This adds public methods for creating detached cose signature given a hash of the payload.