### PR TITLE
Make sure new version number not already in use

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -110,7 +110,6 @@ jobs:
       ### REMOVE THESE!!! ###
           # Checkout the main branch so we can see the correct tag set.
     - name: Fetch and checkout main
-      if: ${{ github.event_name == 'push' }}
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
@@ -121,7 +120,6 @@ jobs:
     #   If the last release is a pre-release, increment the pre-release number, so v1.2.3-pre4 becomes v1.2.3-pre5.
     #   If the last release is an official release, create a new pre-release, so v1.2.3 becomes v1.2.3-pre1.
     - name: Increment pre-release tag
-      if: ${{ github.event_name == 'push' }}
       id: new-tag    # Output: ${{ steps.new-tag.outputs.newtag }}
       run: |
         CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -149,6 +149,23 @@ jobs:
             NEW_TAG="v$BASE_VERSION-pre$((PRE_VERSION + 1))"
           fi
           echo "New tag is $NEW_TAG"
+          echo "Let's make sure this tag doesn't already exist..."
+          while true; do
+            RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
+            if [[ $RESPONSE == *"Not Found"* ]]; then
+              echo "Tag not found. We're good to go."
+              break
+            else
+              echo "Oops! That tag_TAG already exists!"
+              NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
+              echo "Let's try $NEW_TAG"
+            fi
+          done
+
+          # if git rev-parse $NEW_TAG >/dev/null 2>&1; then
+          #   echo "Tag already exists. Exiting."
+          #   exit 1
+          # fi
           echo "::set-output name=newtag::$NEW_TAG"
         else
           echo "Invalid tag format"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -134,8 +134,9 @@ jobs:
           fi
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
-          while i < 5; do
-            i=0
+          i=0
+          
+          while $i -lt 5 ; do
             RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
             if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
@@ -145,7 +146,7 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
-              i++
+              ((i++))
             fi
           done
 
@@ -158,6 +159,8 @@ jobs:
           echo "Invalid tag format"
           exit 1
         fi
+
+# while [ $i -lt 5 ] && [ "$(echo "$RESPONSE" | jq -r '.message')" != "Not Found" ]; ; do
 
   #### PUSH EVENTS ####
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -124,7 +124,7 @@ jobs:
       run: |
         CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)
         echo "Current tag is $CURRENT_TAG"
-        if [[ $CURRENT_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-pre([0-9]+))?$ ]]; then
+        if ([[ $CURRENT_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-pre([0-9]+))?$ ]]); then
           BASE_VERSION=${BASH_REMATCH[1]}
           PRE_VERSION=${BASH_REMATCH[3]}
           if [ -z "$PRE_VERSION" ]; then

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -87,21 +87,76 @@ jobs:
           - os: macos-latest
             dir_command: ls -a -R
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
+    #### RE-ENABLE THESE!!! ####
 
-    # Use the Dotnet Test command to load dependencies, build, and test the code.        
-    - name: Build and Test debug
-      run: dotnet test --verbosity normal CoseSignTool.sln
+    # - name: Checkout code
+    #   uses: actions/checkout@v3
 
-    # List the contents of the working directory to make sure all the artifacts are there.  
-    - name: List working directory
-      run: ${{ matrix.dir_command }}
+    # - name: Setup .NET
+    #   uses: actions/setup-dotnet@v3
+    #   with:
+    #     dotnet-version: 7.0.x
+
+    # # Use the Dotnet Test command to load dependencies, build, and test the code.        
+    # - name: Build and Test debug
+    #   run: dotnet test --verbosity normal CoseSignTool.sln
+
+    # # List the contents of the working directory to make sure all the artifacts are there.  
+    # - name: List working directory
+    #   run: ${{ matrix.dir_command }}
+
+
+      ### REMOVE THESE!!! ###
+          # Checkout the main branch so we can see the correct tag set.
+    - name: Fetch and checkout main
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git fetch
+        git checkout main
+
+    # Create a semantically versioned tag that increments the last release.
+    #   If the last release is a pre-release, increment the pre-release number, so v1.2.3-pre4 becomes v1.2.3-pre5.
+    #   If the last release is an official release, create a new pre-release, so v1.2.3 becomes v1.2.3-pre1.
+    - name: Increment pre-release tag
+      if: ${{ github.event_name == 'push' }}
+      id: new-tag    # Output: ${{ steps.new-tag.outputs.newtag }}
+      run: |
+        CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)
+        echo "Current tag is $CURRENT_TAG"
+        if [[ $CURRENT_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-pre([0-9]+))?$ ]]; then
+          BASE_VERSION=${BASH_REMATCH[1]}
+          PRE_VERSION=${BASH_REMATCH[3]}
+          if [ -z "$PRE_VERSION" ]; then
+            NEW_TAG="v$BASE_VERSION-pre1"
+          else
+            NEW_TAG="v$BASE_VERSION-pre$((PRE_VERSION + 1))"
+          fi
+          echo "New tag is $NEW_TAG"
+          echo "Let's make sure this tag doesn't already exist..."
+          while true; do
+            RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
+            if [[ $RESPONSE == *"Not Found"* ]]; then
+              echo "Tag not found. We're good to go."
+              break
+            else
+              echo "Oops! That tag_TAG already exists!"
+              NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
+              echo "Let's try $NEW_TAG"
+            fi
+          done
+
+          if git rev-parse $NEW_TAG >/dev/null 2>&1; then
+            echo "Tag already exists. Exiting."
+            exit 1
+          fi
+          echo "::set-output name=newtag::$NEW_TAG"
+        else
+          echo "Invalid tag format"
+          exit 1
+        fi
 
   #### PUSH EVENTS ####
 
@@ -135,7 +190,7 @@ jobs:
     #   If the last release is a pre-release, increment the pre-release number, so v1.2.3-pre4 becomes v1.2.3-pre5.
     #   If the last release is an official release, create a new pre-release, so v1.2.3 becomes v1.2.3-pre1.
     - name: Increment pre-release tag
-      # if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' }}
       id: new-tag    # Output: ${{ steps.new-tag.outputs.newtag }}
       run: |
         CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -140,7 +140,7 @@ jobs:
           maxTries=5
 
           while true ; do
-            echo "i is $i"
+            echo "This is try $tries"
             RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
             if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -155,7 +155,7 @@ jobs:
               echo "Oops! That tag already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
-              ((tries++))
+              tries=$((tries+1))
             fi
           done
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,10 +135,11 @@ jobs:
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
           
-          NEW_TAG=$CURRENT_TAG
+          NEW_TAG="v1.1.0-pre1""
           i=0
 
-          while true ; do
+          while i -lt 5 ; do
+            echo "i is $i"
             RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
             if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
@@ -148,6 +149,7 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
+              i=$((i+1))
             fi
           done
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -134,9 +134,10 @@ jobs:
           fi
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
-          while true; do
-            echo "New tag is $NEW_TAG"
+          while i < 5; do
+            i=0
             RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
+            echo "RESPONSE: $RESPONSE"
             if [[ $RESPONSE == *"Not Found"* ]]; then
               echo "Tag not found. We're good to go."
               break
@@ -144,6 +145,7 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
+              i++
             fi
           done
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -136,7 +136,7 @@ jobs:
           echo "Let's make sure this tag doesn't already exist..."
           
           while true ; do
-            RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
+            RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
             if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
               echo "Tag not found. We're good to go."

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,7 +135,7 @@ jobs:
     #   If the last release is a pre-release, increment the pre-release number, so v1.2.3-pre4 becomes v1.2.3-pre5.
     #   If the last release is an official release, create a new pre-release, so v1.2.3 becomes v1.2.3-pre1.
     - name: Increment pre-release tag
-      if: ${{ github.event_name == 'push' }}
+      # if: ${{ github.event_name == 'push' }}
       id: new-tag    # Output: ${{ steps.new-tag.outputs.newtag }}
       run: |
         CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)
@@ -162,10 +162,10 @@ jobs:
             fi
           done
 
-          # if git rev-parse $NEW_TAG >/dev/null 2>&1; then
-          #   echo "Tag already exists. Exiting."
-          #   exit 1
-          # fi
+          if git rev-parse $NEW_TAG >/dev/null 2>&1; then
+            echo "Tag already exists. Exiting."
+            exit 1
+          fi
           echo "::set-output name=newtag::$NEW_TAG"
         else
           echo "Invalid tag format"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,6 +135,9 @@ jobs:
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
           
+          NEW_TAG=$CURRENT_TAG
+          i=0
+
           while true ; do
             RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -137,8 +137,8 @@ jobs:
           while i < 5; do
             i=0
             RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
-            echo "RESPONSE: $RESPONSE"
-            if [[ $RESPONSE == *"Not Found"* ]]; then
+            echo "$RESPONSE" | jq -r '.message'
+            if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
               echo "Tag not found. We're good to go."
               break
             else

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,7 +135,7 @@ jobs:
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
           
-          NEW_TAG="v1.1.0-pre1""
+          NEW_TAG="v1.1.0-pre1"
           i=0
 
           while i -lt 5 ; do

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -139,10 +139,11 @@ jobs:
           tries=0
           maxTries=5
 
-          while true ; do
+          while true; do
             echo "This is try $tries"
             RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
-            echo "$RESPONSE" | jq -r '.message'
+            MESSAGE="$RESPONSE" | jq -r '.message'
+            echo "Message is $MESSAGE"
             if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
               echo "Tag not found. We're good to go."
               break
@@ -151,7 +152,7 @@ jobs:
                 echo "Max tries reached. Exiting."
                 exit 1
               fi
-              echo "Oops! That tag_TAG already exists!"
+              echo "Oops! That tag already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
               ((tries++))

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,6 +135,7 @@ jobs:
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
           while true; do
+            echo "New tag is $NEW_TAG"
             RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             if [[ $RESPONSE == *"Not Found"* ]]; then
               echo "Tag not found. We're good to go."

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -154,7 +154,7 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
-              ((tries++)))
+              ((tries++))
             fi
           done
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -90,8 +90,8 @@ jobs:
 
     #### RE-ENABLE THESE!!! ####
 
-    # - name: Checkout code
-    #   uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v3
 
     # - name: Setup .NET
     #   uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -154,6 +154,7 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
+              ((tries++)))
             fi
           done
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -124,7 +124,7 @@ jobs:
       run: |
         CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)
         echo "Current tag is $CURRENT_TAG"
-        if ([[ $CURRENT_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-pre([0-9]+))?$ ]]); then
+        if [[ $CURRENT_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-pre([0-9]+))?$ ]]; then
           BASE_VERSION=${BASH_REMATCH[1]}
           PRE_VERSION=${BASH_REMATCH[3]}
           if [ -z "$PRE_VERSION" ]; then
@@ -134,9 +134,8 @@ jobs:
           fi
           echo "New tag is $NEW_TAG"
           echo "Let's make sure this tag doesn't already exist..."
-          i=0
           
-          while $i -lt 5 ; do
+          while true ; do
             RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
             if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
@@ -146,7 +145,6 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
-              ((i++))
             fi
           done
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -138,7 +138,7 @@ jobs:
           NEW_TAG="v1.1.0-pre1"
           i=0
 
-          while i -lt 5 ; do
+          while [$i -lt 5] ; do
             echo "i is $i"
             RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
@@ -149,14 +149,10 @@ jobs:
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
-              i=$((i+1))
+              ((i++))
             fi
           done
 
-          if git rev-parse $NEW_TAG >/dev/null 2>&1; then
-            echo "Tag already exists. Exiting."
-            exit 1
-          fi
           echo "::set-output name=newtag::$NEW_TAG"
         else
           echo "Invalid tag format"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -87,85 +87,21 @@ jobs:
           - os: macos-latest
             dir_command: ls -a -R
     steps:
-
-    #### RE-ENABLE THESE!!! ####
-
     - name: Checkout code
       uses: actions/checkout@v3
 
-    # - name: Setup .NET
-    #   uses: actions/setup-dotnet@v3
-    #   with:
-    #     dotnet-version: 7.0.x
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
 
-    # # Use the Dotnet Test command to load dependencies, build, and test the code.        
-    # - name: Build and Test debug
-    #   run: dotnet test --verbosity normal CoseSignTool.sln
+    # Use the Dotnet Test command to load dependencies, build, and test the code.        
+    - name: Build and Test debug
+      run: dotnet test --verbosity normal CoseSignTool.sln
 
-    # # List the contents of the working directory to make sure all the artifacts are there.  
-    # - name: List working directory
-    #   run: ${{ matrix.dir_command }}
-
-
-      ### REMOVE THESE!!! ###
-          # Checkout the main branch so we can see the correct tag set.
-    - name: Fetch and checkout main
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git fetch
-        git checkout main
-
-    # Create a semantically versioned tag that increments the last release.
-    #   If the last release is a pre-release, increment the pre-release number, so v1.2.3-pre4 becomes v1.2.3-pre5.
-    #   If the last release is an official release, create a new pre-release, so v1.2.3 becomes v1.2.3-pre1.
-    - name: Increment pre-release tag
-      id: new-tag    # Output: ${{ steps.new-tag.outputs.newtag }}
-      run: |
-        CURRENT_TAG=$(git tag | sort --version-sort | tail -n1)
-        echo "Current tag is $CURRENT_TAG"
-        if [[ $CURRENT_TAG =~ ^v([0-9]+\.[0-9]+\.[0-9]+)(-pre([0-9]+))?$ ]]; then
-          BASE_VERSION=${BASH_REMATCH[1]}
-          PRE_VERSION=${BASH_REMATCH[3]}
-          if [ -z "$PRE_VERSION" ]; then
-            NEW_TAG="v$BASE_VERSION-pre1"
-          else
-            NEW_TAG="v$BASE_VERSION-pre$((PRE_VERSION + 1))"
-          fi
-          echo "New tag is $NEW_TAG"
-          echo "Let's make sure this tag doesn't already exist..."
-          
-          NEW_TAG="v1.1.0-pre1"
-          tries=0
-          maxTries=5
-
-          while true; do
-            echo "This is try $tries"
-            RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
-            MESSAGE="$RESPONSE" | jq -r '.message'
-            echo "Message is $MESSAGE"
-            if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
-              echo "Tag not found. We're good to go."
-              break
-            else
-              if [ $tries -ge $maxTries ]; then
-                echo "Max tries reached. Exiting."
-                exit 1
-              fi
-              echo "Oops! That tag already exists!"
-              NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
-              echo "Let's try $NEW_TAG"
-              tries=$((tries+1))
-            fi
-          done
-
-          echo "::set-output name=newtag::$NEW_TAG"
-        else
-          echo "Invalid tag format"
-          exit 1
-        fi
-
-# while [ $i -lt 5 ] && [ "$(echo "$RESPONSE" | jq -r '.message')" != "Not Found" ]; ; do
+    # List the contents of the working directory to make sure all the artifacts are there.  
+    - name: List working directory
+      run: ${{ matrix.dir_command }}
 
   #### PUSH EVENTS ####
 
@@ -213,23 +149,28 @@ jobs:
             NEW_TAG="v$BASE_VERSION-pre$((PRE_VERSION + 1))"
           fi
           echo "New tag is $NEW_TAG"
+
           echo "Let's make sure this tag doesn't already exist..."
+          tries=0
+          maxTries=5
           while true; do
-            RESPONSE=$(curl -sl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
-            if [[ $RESPONSE == *"Not Found"* ]]; then
+            echo "This is try $tries"
+            RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
+            if [ "$(echo "$RESPONSE" | jq -r '.message')" == "Not Found" ]; then
               echo "Tag not found. We're good to go."
               break
             else
-              echo "Oops! That tag_TAG already exists!"
+              if [ $tries -ge $maxTries ]; then
+                echo "Max tries reached. Exiting."
+                exit 1
+              fi
+              echo "Oops! That tag already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
+              tries=$((tries+1))
             fi
           done
 
-          if git rev-parse $NEW_TAG >/dev/null 2>&1; then
-            echo "Tag already exists. Exiting."
-            exit 1
-          fi
           echo "::set-output name=newtag::$NEW_TAG"
         else
           echo "Invalid tag format"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -136,9 +136,10 @@ jobs:
           echo "Let's make sure this tag doesn't already exist..."
           
           NEW_TAG="v1.1.0-pre1"
-          i=0
+          tries=0
+          maxTries=5
 
-          while [$i -lt 5] ; do
+          while true ; do
             echo "i is $i"
             RESPONSE=$(curl -sl https://api.github.com/repos/microsoft/CoseSignTool/releases/tags/$NEW_TAG)
             echo "$RESPONSE" | jq -r '.message'
@@ -146,10 +147,13 @@ jobs:
               echo "Tag not found. We're good to go."
               break
             else
+              if [ $tries -ge $maxTries ]; then
+                echo "Max tries reached. Exiting."
+                exit 1
+              fi
               echo "Oops! That tag_TAG already exists!"
               NEW_TAG="${NEW_TAG%-*}-pre$(( ${NEW_TAG##*-pre} + 1 ))"   # Increment the prerelease number.
               echo "Let's try $NEW_TAG"
-              ((i++))
             fi
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased](https://github.com/microsoft/CoseSignTool/tree/HEAD)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre2...HEAD)
+
+**Merged pull requests:**
+
+- fix nuspec location [\#59](https://github.com/microsoft/CoseSignTool/pull/59) ([JeromySt](https://github.com/JeromySt))
+
 ## [v1.1.0-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre2) (2023-11-10)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre1...v1.1.0-pre2)


### PR DESCRIPTION
In the "Increment pre-release tag" build step, we use GitHub commands to get the latest version number. Sometimes GitHub fails to return the last version on the stack.
This PR uses a web request to make sure the new proposed version number is not already in use, and if it is, increments and repeats until it finds a free version number.