### PR TITLE
update moq dependency to 4.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## [Unreleased](https://github.com/microsoft/CoseSignTool/tree/HEAD)
+## [v1.1.0-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre3) (2023-11-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre2...HEAD)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre2...v1.1.0-pre3)
 
 **Merged pull requests:**
 
+- Make sure new version number not already in use [\#60](https://github.com/microsoft/CoseSignTool/pull/60) ([lemccomb](https://github.com/lemccomb))
 - fix nuspec location [\#59](https://github.com/microsoft/CoseSignTool/pull/59) ([JeromySt](https://github.com/JeromySt))
 
 ## [v1.1.0-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre2) (2023-11-10)

--- a/CoseDetachedSIgnature.Tests/CoseDetachedSignature.Tests.csproj
+++ b/CoseDetachedSIgnature.Tests/CoseDetachedSignature.Tests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
       <PackageReference Include="FluentAssertions" Version="6.12.0" />
-      <PackageReference Include="Moq" Version="4.18.4" />
+      <PackageReference Include="Moq" Version="[4.18.4]"/>
       <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
       <PackageReference Include="NUnit" Version="3.13.3" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />

--- a/CoseDetachedSIgnature.Tests/CoseDetachedSignature.Tests.csproj
+++ b/CoseDetachedSIgnature.Tests/CoseDetachedSignature.Tests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
       <PackageReference Include="FluentAssertions" Version="6.12.0" />
-      <PackageReference Include="Moq" Version="4.20.69" />
+      <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
       <PackageReference Include="NUnit" Version="3.13.3" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />

--- a/CoseHandler.Tests/CoseHandler.Tests.csproj
+++ b/CoseHandler.Tests/CoseHandler.Tests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/CoseHandler.Tests/CoseHandler.Tests.csproj
+++ b/CoseHandler.Tests/CoseHandler.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -20,9 +20,9 @@
     </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
+++ b/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Moq" Version="[4.18.4]" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
+++ b/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
         <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
-        <PackageReference Include="Moq" Version="4.20.69" />
+        <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CoseSign1.Tests/CoseSign1.Tests.csproj
+++ b/CoseSign1.Tests/CoseSign1.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />

--- a/CoseSign1.Tests/CoseSign1.Tests.csproj
+++ b/CoseSign1.Tests/CoseSign1.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />

--- a/CoseSignTool.tests/CoseSignTool.tests.csproj
+++ b/CoseSignTool.tests/CoseSignTool.tests.csproj
@@ -31,7 +31,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-		<PackageReference Include="Moq" Version="4.20.69" />
+		<PackageReference Include="Moq" Version="4.18.4" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/CoseSignTool.tests/CoseSignTool.tests.csproj
+++ b/CoseSignTool.tests/CoseSignTool.tests.csproj
@@ -31,7 +31,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="Moq" Version="[4.18.4]" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />


### PR DESCRIPTION
To address CVE in moq versions >4.18.4, force 4.18.4.