### PR TITLE
Fixing Command Line False Positives 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.1.0-pre4](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre4) (2023-11-15)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre3...v1.1.0-pre4)
+
+**Merged pull requests:**
+
+- update moq dependency to 4.18.4 [\#61](https://github.com/microsoft/CoseSignTool/pull/61) ([JeromySt](https://github.com/JeromySt))
+
 ## [v1.1.0-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre3) (2023-11-15)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre2...v1.1.0-pre3)
@@ -35,7 +43,7 @@
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -45,13 +53,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
-
 ## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
+
+## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
 
 **Merged pull requests:**
 

--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -287,9 +287,9 @@ public class CoseHandlerSignValidateTests
     {
         ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, new X509Certificate2(PrivateKeyCertFileChained));
         signedBytes.ToArray().Should().NotBeNull();
-        X509ChainTrustValidator chainValidator = new(allowUntrusted: true);
-        CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, null, RevMode)
-            .Success.Should().Be(false);
+        X509ChainTrustValidator chainValidator = new(revocationMode: RevMode, allowUntrusted: true);
+        CoseHandler.Validate(signedBytes.ToArray(), chainValidator, Payload1Bytes)
+            .Success.Should().Be(true);
     }
     #endregion
 

--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -288,8 +288,13 @@ public class CoseHandlerSignValidateTests
         ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, new X509Certificate2(PrivateKeyCertFileChained));
         signedBytes.ToArray().Should().NotBeNull();
         X509ChainTrustValidator chainValidator = new(revocationMode: RevMode, allowUntrusted: true);
-        CoseHandler.Validate(signedBytes.ToArray(), chainValidator, Payload1Bytes)
-            .Success.Should().Be(true);
+        var result = CoseHandler.Validate(signedBytes.ToArray(), chainValidator, Payload1Bytes);
+        result.Success.Should().Be(true);
+        result.InnerResults.Count.Should().Be(1);
+        result.InnerResults[0].PassedValidation.Should().BeTrue();
+        result.InnerResults[0].ResultMessage.Should().Be("Certificate was allowed because AllowUntrusted was specified.");
+
+        Console.WriteLine(result);
     }
     #endregion
 

--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -268,13 +268,26 @@ public class CoseHandlerSignValidateTests
     }
 
     /// <summary>
-    /// Validate that signing with an untrusted cert causes validation to return ValidationResultTypes.ValidUntrusted
+    /// Validate that signing with an untrusted cert causes validation to fail
     /// </summary>
     [TestMethod]
     public void Untrusted()
     {
         ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, new X509Certificate2(PrivateKeyCertFileChained));
         signedBytes.ToArray().Should().NotBeNull();
+        CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, null, RevMode)
+            .Success.Should().Be(false);
+    }
+
+    /// <summary>
+    /// Validate that signing with an untrusted cert causes validation to return ValidationResultTypes.ValidUntrusted
+    /// </summary>
+    [TestMethod]
+    public void UntrustedAllowed()
+    {
+        ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, new X509Certificate2(PrivateKeyCertFileChained));
+        signedBytes.ToArray().Should().NotBeNull();
+        X509ChainTrustValidator chainValidator = new(allowUntrusted: true);
         CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, null, RevMode)
             .Success.Should().Be(false);
     }

--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -263,7 +263,7 @@ public class CoseHandlerSignValidateTests
     {
         ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, SelfSignedCert);
         signedBytes.ToArray().Should().NotBeNull();
-        var result = CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, null, RevMode);
+        var result = CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, new List<X509Certificate2> { SelfSignedCert }, RevMode);
         result.Success.Should().Be(true);
     }
 
@@ -276,7 +276,7 @@ public class CoseHandlerSignValidateTests
         ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, new X509Certificate2(PrivateKeyCertFileChained));
         signedBytes.ToArray().Should().NotBeNull();
         CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, null, RevMode)
-            .Success.Should().Be(true);
+            .Success.Should().Be(false);
     }
     #endregion
 

--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -293,8 +293,6 @@ public class CoseHandlerSignValidateTests
         result.InnerResults.Count.Should().Be(1);
         result.InnerResults[0].PassedValidation.Should().BeTrue();
         result.InnerResults[0].ResultMessage.Should().Be("Certificate was allowed because AllowUntrusted was specified.");
-
-        Console.WriteLine(result);
     }
     #endregion
 

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -561,7 +561,8 @@ public static class CoseHandler
         // Validate trust of the signing certificate for the message if a CoseSign1MessageValidator was passed.
         if (!validator.TryValidate(msg, out List<CoseSign1ValidationResult> certValidationResults))
         {
-            return new ValidationResult(false, null, certValidationResults);
+            errorCodes.Add(ValidationFailureCode.CertificateChainInvalid);
+            return new ValidationResult(false, errorCodes, certValidationResults);
         }
 
         // Get the signing certificate
@@ -699,7 +700,7 @@ public static class CoseHandler
                 roots,
                 revocationMode,
                 allowUnprotected: true,
-                allowUntrusted: true);
+                allowUntrusted: false);
 
         // If validating CommonName, we'll do that first, and set it to call for chain trust validation when it finishes.
         if (!string.IsNullOrWhiteSpace(requiredCommonName))

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -566,7 +566,7 @@ public static class CoseHandler
         // Validate trust of the signing certificate for the message if a CoseSign1MessageValidator was passed.
         if (!validator.TryValidate(msg, out List<CoseSign1ValidationResult> certValidationResults))
         {
-            errorCodes.Add(ValidationFailureCode.CertificateChainInvalid);
+            errorCodes.Add(ValidationFailureCode.TrustValidationFailed);
             return new ValidationResult(false, errorCodes, certValidationResults);
         }
 

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -692,15 +692,15 @@ public static class CoseHandler
     internal static CoseSign1MessageValidator GetValidator(
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null
-        )
+        string? requiredCommonName = null,
+        bool allowUntrusted = false)
     {
         // Create a validator for the certificate trust chain.
         CoseSign1MessageValidator chainTrustValidator = new X509ChainTrustValidator(
                 roots,
                 revocationMode,
                 allowUnprotected: true,
-                allowUntrusted: false);
+                allowUntrusted: allowUntrusted);
 
         // If validating CommonName, we'll do that first, and set it to call for chain trust validation when it finishes.
         if (!string.IsNullOrWhiteSpace(requiredCommonName))

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -323,8 +323,9 @@ public static class CoseHandler
         byte[]? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName), payload);
+        string? requiredCommonName = null,
+        bool allowUntrusted = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
 
     /// <summary>
     /// Validates a detached COSE signature in memory.
@@ -339,8 +340,9 @@ public static class CoseHandler
         Stream payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName), payload);
+        string? requiredCommonName = null,
+        bool allowUntrusted = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
 
     /// <summary>
     /// Validates a detached or embedded COSE signature in memory.
@@ -355,8 +357,9 @@ public static class CoseHandler
         byte[]? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName), payload);
+        string? requiredCommonName = null,
+        bool allowUntrusted = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
 
     /// <summary>
     /// Validates a COSE signature file.
@@ -371,10 +374,11 @@ public static class CoseHandler
         FileInfo? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
+        string? requiredCommonName = null,
+        bool allowUntrusted = false)
         => Validate(
             File.ReadAllBytes(signature.FullName),
-            GetValidator(roots, revocationMode, requiredCommonName),
+            GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted),
             payload?.OpenRead());
 
     /// <summary>
@@ -390,8 +394,9 @@ public static class CoseHandler
         Stream? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName), payload);
+        string? requiredCommonName = null,
+        bool allowUntrusted = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
 
     /// <summary>
     /// Validates a detached or embedded COSE signature in  memory.

--- a/CoseHandler/CoseValidationError.cs
+++ b/CoseHandler/CoseValidationError.cs
@@ -41,6 +41,7 @@ public readonly struct CoseValidationError
         { ValidationFailureCode.NoPublicKey, "No public key could be found for the signing certificate."},
         { ValidationFailureCode.CertificateChainUnreadable, "One or more certificates in the certificate chain could not be read."},
         { ValidationFailureCode.CertificateChainInvalid, "Certificate chain validation failed." },
+        { ValidationFailureCode.TrustValidationFailed, "The signature failed to validate against the trust validator." },
         { ValidationFailureCode.PayloadMismatch, "The supplied or embedded payload does not match the hash of the payload that was signed." },
         { ValidationFailureCode.PayloadMissing, "The detached signature could not be validated because the original payload was nut supplied."},
         { ValidationFailureCode.PayloadUnreadable, "The payload content could not be read."},

--- a/CoseHandler/CoseValidationError.cs
+++ b/CoseHandler/CoseValidationError.cs
@@ -46,5 +46,6 @@ public readonly struct CoseValidationError
         { ValidationFailureCode.PayloadUnreadable, "The payload content could not be read."},
         { ValidationFailureCode.RedundantPayload, "The embedded signature was not validated because external payload was also specified."},
         { ValidationFailureCode.CoseHeadersInvalid, "The COSE headers in the signature could not be read." },
+        { ValidationFailureCode.Unknown, "An unknown error was thrown." }
     };
 }

--- a/CoseHandler/ValidationFailureCode.cs
+++ b/CoseHandler/ValidationFailureCode.cs
@@ -39,6 +39,11 @@ public enum ValidationFailureCode
     CertificateChainInvalid,
 
     /// <summary>
+    /// The signature failed to validate against the trust validator.
+    /// </summary>
+    TrustValidationFailed,
+
+    /// <summary>
     /// The supplied or embedded payload does not match the hash of the original payload.
     /// </summary>
     PayloadMismatch,

--- a/CoseHandler/ValidationResult.cs
+++ b/CoseHandler/ValidationResult.cs
@@ -88,7 +88,7 @@ public struct ValidationResult
         if (!verbose)
         {
             // Print just the header and the top level error messages.
-            return $"{header}{errorBlock}";
+            return $"{header}{errorBlock}{footer}";
         }
 
         // We're in Verbose mode, so get all the Includes from the internal validators.

--- a/CoseSignTool.tests/ValidateCommandTests.cs
+++ b/CoseSignTool.tests/ValidateCommandTests.cs
@@ -61,11 +61,11 @@ public class ValidateCommandTests
         // sign detached
         string[] args1 = { "sign", @"/p", PayloadFile, @"/pfx", PrivateKeyCertFileSelfSigned };
         CST.Main(args1).Should().Be((int)ExitCode.Success, "Detach sign failed.");
-        string coseFile = PayloadFile + ".cose";
+        using FileStream coseFile = new(PayloadFile + ".cose", FileMode.Open);
 
         // setup validator
         var validator = new ValidateCommand();
-        var result = validator.RunCoseHandlerCommand(new FileStream(coseFile, FileMode.Open),
+        var result = validator.RunCoseHandlerCommand(coseFile,
                                                      new FileInfo(PayloadFile),
                                                      new System.Collections.Generic.List<X509Certificate2> { SelfSignedCert },
                                                      X509RevocationMode.Online,

--- a/CoseSignTool.tests/ValidateCommandTests.cs
+++ b/CoseSignTool.tests/ValidateCommandTests.cs
@@ -90,7 +90,7 @@ public class ValidateCommandTests
         var result = validator.RunCoseHandlerCommand(new FileStream(coseFile, FileMode.Open), new FileInfo(PayloadFile), null, X509RevocationMode.Online, null, false);
         result.Success.Should().BeFalse();
         result.Errors.Should().ContainSingle();
-        result.Errors[0].ErrorCode.Should().Be(ValidationFailureCode.CertificateChainInvalid);
+        result.Errors[0].ErrorCode.Should().Be(ValidationFailureCode.TrustValidationFailed);
     }
 
     /// <summary>

--- a/CoseSignTool.tests/ValidateCommandTests.cs
+++ b/CoseSignTool.tests/ValidateCommandTests.cs
@@ -83,11 +83,11 @@ public class ValidateCommandTests
         // sign detached
         string[] args1 = { "sign", @"/p", PayloadFile, @"/pfx", PrivateKeyCertFileSelfSigned };
         CST.Main(args1).Should().Be((int)ExitCode.Success, "Detach sign failed.");
-        string coseFile = PayloadFile + ".cose";
+        using FileStream coseFile = new(PayloadFile + ".cose", FileMode.Open);
 
         // setup validator
         var validator = new ValidateCommand();
-        var result = validator.RunCoseHandlerCommand(new FileStream(coseFile, FileMode.Open), new FileInfo(PayloadFile), null, X509RevocationMode.Online, null, false);
+        var result = validator.RunCoseHandlerCommand(coseFile, new FileInfo(PayloadFile), null, X509RevocationMode.Online, null, false);
         result.Success.Should().BeFalse();
         result.Errors.Should().ContainSingle();
         result.Errors[0].ErrorCode.Should().Be(ValidationFailureCode.TrustValidationFailed);
@@ -102,11 +102,11 @@ public class ValidateCommandTests
         // sign detached
         string[] args1 = { "sign", @"/p", PayloadFile, @"/pfx", PrivateKeyCertFileSelfSigned };
         CST.Main(args1).Should().Be((int)ExitCode.Success, "Detach sign failed.");
-        string coseFile = PayloadFile + ".cose";
+        using FileStream coseFile = new(PayloadFile + ".cose", FileMode.Open);
 
         // setup validator
         var validator = new ValidateCommand();
-        var result = validator.RunCoseHandlerCommand(new FileStream(coseFile, FileMode.Open), new FileInfo(PayloadFile), null, X509RevocationMode.Online, null, allowUntrusted: true);
+        var result = validator.RunCoseHandlerCommand(coseFile, new FileInfo(PayloadFile), null, X509RevocationMode.Online, null, allowUntrusted: true);
         result.Success.Should().BeTrue();
         result.InnerResults.Should().ContainSingle();
         result.InnerResults[0].PassedValidation.Should().BeTrue();

--- a/CoseSignTool.tests/ValidateCommandTests.cs
+++ b/CoseSignTool.tests/ValidateCommandTests.cs
@@ -1,9 +1,66 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace CoseSignTool.tests;
+namespace CoseSignUnitTests;
 
-internal class ValidateCommandTests
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using CST = CoseSignTool.CoseSignTool;
+
+[TestClass]
+public class ValidateCommandTests
 {
-    // Placeholder for tests for the ValidateCommand class
+    // Certificates
+    private static readonly X509Certificate2 SelfSignedCert = TestCertificateUtils.CreateCertificate(nameof(CoseHandlerSignValidateTests) + " self signed");    // A self-signed cert
+    private static readonly X509Certificate2Collection CertChain1 = TestCertificateUtils.CreateTestChain(nameof(CoseHandlerSignValidateTests) + " set 1");      // Two complete cert chains
+    private static readonly X509Certificate2Collection CertChain2 = TestCertificateUtils.CreateTestChain(nameof(CoseHandlerSignValidateTests) + " set 2");
+    private static readonly X509Certificate2 Root1Priv = CertChain1[0];                                                                                         // Roots from the chains       
+    private static readonly X509Certificate2 Root2Priv = CertChain2[0];
+    private static readonly X509Certificate2 Int1Priv = CertChain1[1];
+    private static readonly X509Certificate2 Leaf1Priv = CertChain1[^1];                                                                                        // Leaf node certs
+    private static readonly X509Certificate2 Leaf2Priv = CertChain2[^1];
+
+    // File paths to export them to
+    private static readonly string PrivateKeyCertFileSelfSigned = Path.GetTempFileName() + "_SelfSigned.pfx";
+    private static readonly string PublicKeyCertFileSelfSigned = Path.GetTempFileName() + "_SelfSigned.cer";
+    private static readonly string PrivateKeyRootCertFile = Path.GetTempFileName() + ".pfx";
+    private static readonly string PublicKeyIntermediateCertFile = Path.GetTempFileName() + ".cer";
+    private static readonly string PublicKeyRootCertFile = Path.GetTempFileName() + ".cer";
+    private static readonly string PrivateKeyCertFileChained = Path.GetTempFileName() + ".pfx";
+    private static readonly string PrivateKeyCertFileChainedWithPassword = Path.GetTempFileName() + ".pfx";
+    private static readonly string CertPassword = Guid.NewGuid().ToString();
+
+
+    private static string PayloadFile;
+    private static readonly byte[] Payload1Bytes = Encoding.ASCII.GetBytes("Payload1!");
+
+    public ValidateCommandTests()
+    {
+        // make payload file
+        PayloadFile = Path.GetTempFileName();
+        File.WriteAllBytes(PayloadFile, Payload1Bytes);
+
+        // export generated certs to files
+        File.WriteAllBytes(PrivateKeyCertFileSelfSigned, SelfSignedCert.Export(X509ContentType.Pkcs12));
+        File.WriteAllBytes(PublicKeyCertFileSelfSigned, SelfSignedCert.Export(X509ContentType.Cert));
+        File.WriteAllBytes(PrivateKeyRootCertFile, Root1Priv.Export(X509ContentType.Pkcs12));
+        File.WriteAllBytes(PublicKeyRootCertFile, Root1Priv.Export(X509ContentType.Cert));
+        File.WriteAllBytes(PublicKeyIntermediateCertFile, Int1Priv.Export(X509ContentType.Cert));
+        File.WriteAllBytes(PrivateKeyCertFileChained, Leaf1Priv.Export(X509ContentType.Pkcs12));
+        File.WriteAllBytes(PrivateKeyCertFileChainedWithPassword, Leaf1Priv.Export(X509ContentType.Pkcs12, CertPassword));
+    }
+
+    // Validates that signatures made from untrusted chains are rejected
+    [TestMethod]
+    public void ValidateTrustTest()
+    {
+        // sign detached
+        string[] args1 = { "sign", @"/p", PayloadFile, @"/pfx", PrivateKeyCertFileChained };
+        CST.Main(args1).Should().Be((int)ExitCode.Success, "Detach sign failed.");
+
+        // validate without the root cert installed or passed in
+        string[] args2 = { "validate", @"/payload", PayloadFile, @"/sf", PayloadFile + ".cose" };
+        CST.Main(args2).Should().Be((int)ExitCode.CertificateChainValidationFailure);
+    }
 }

--- a/CoseSignTool/ExitCode.cs
+++ b/CoseSignTool/ExitCode.cs
@@ -51,6 +51,11 @@ public enum ExitCode
     StoreCertificateNotFound = 1889,
 
     /// <summary>
+    /// The signature failed to validate against the trust validator.
+    /// </summary>
+    TrustValidationFailure = 1890,
+
+    /// <summary>
     /// The certificate chain failed validation.
     /// </summary>
     CertificateChainValidationFailure = 1891,

--- a/CoseSignTool/GetCommand.cs
+++ b/CoseSignTool/GetCommand.cs
@@ -36,7 +36,7 @@ public class GetCommand : ValidateCommand
     }
 
     // This is consumed by ValidateCommand.Run, which uses it in place of the call to CoseParser.Validate.
-    protected override ValidationResult RunCoseHandlerCommand(Stream signature, FileInfo? payloadFile, List<X509Certificate2>? rootCerts, X509RevocationMode revocationMode, string? commonName)
+    protected internal override ValidationResult RunCoseHandlerCommand(Stream signature, FileInfo? payloadFile, List<X509Certificate2>? rootCerts, X509RevocationMode revocationMode, string? commonName, bool allowUntrusted)
     {
         // Get the embedded payload content.
         string? content = CoseHandler.GetPayload(signature, out ValidationResult result, rootCerts, revocationMode, commonName);

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -133,7 +133,7 @@ public class ValidateCommand : CoseCommand
             Console.Error.WriteLine(result.ToString());
 
             return result.Success ? ExitCode.Success
-                : result.Errors?.Count > 0 ? ErrorMap[result.Errors.FirstOrDefault().ErrorCode]
+                : result.Errors?.Count > 0 || result.Errors is not null ? ErrorMap[result.Errors.FirstOrDefault().ErrorCode]
                 : ExitCode.UnknownError;
         }
         catch (ArgumentException ex)

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -133,7 +133,7 @@ public class ValidateCommand : CoseCommand
             Console.Error.WriteLine(result.ToString());
 
             return result.Success ? ExitCode.Success
-                : result.Errors?.Count > 0 || result.Errors is not null ? ErrorMap[result.Errors.FirstOrDefault().ErrorCode]
+                : result.Errors?.Count > 0 ? ErrorMap[result.Errors.FirstOrDefault().ErrorCode]
                 : ExitCode.UnknownError;
         }
         catch (ArgumentException ex)

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -127,7 +127,8 @@ public class ValidateCommand : CoseCommand
                 PayloadFile,
                 rootCerts,
                 RevocationMode,
-                CommonName);
+                CommonName,
+                AllowUntrusted);
 
             // Write the result to console on STDERR
             Console.Error.WriteLine(result.ToString());
@@ -154,16 +155,20 @@ public class ValidateCommand : CoseCommand
     }
 
     // A pass-through method to let derived classes modify the command and otherwise re-use the surrounding code.
-    protected virtual ValidationResult RunCoseHandlerCommand(
+    protected internal virtual ValidationResult RunCoseHandlerCommand(
         Stream signature,
         FileInfo? payload,
         List<X509Certificate2>? rootCerts,
         X509RevocationMode revocationMode,
-        string? commonName)
+        string? commonName,
+        bool allowUntrusted)
         => CoseHandler.Validate(
             signature,
             payload?.OpenRead(),
-            rootCerts, revocationMode, commonName);
+            rootCerts,
+            revocationMode,
+            commonName,
+            allowUntrusted);
 
     //<inheritdoc />
     protected internal override void ApplyOptions(CommandLineConfigurationProvider provider)

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -38,6 +38,7 @@ public class ValidateCommand : CoseCommand
         { ValidationFailureCode.RedundantPayload, ExitCode.PayloadValidationError },
         { ValidationFailureCode.SigningCertificateUnreadable, ExitCode.CertificateLoadFailure },
         { ValidationFailureCode.CertificateChainInvalid, ExitCode.CertificateChainValidationFailure },
+        { ValidationFailureCode.TrustValidationFailed, ExitCode.TrustValidationFailure },
         { ValidationFailureCode.Unknown, ExitCode.UnknownError },
     };
 


### PR DESCRIPTION
Addresses https://github.com/microsoft/CoseSignTool/issues/66

- The default trust validator used by the validate command line had the AllowUntrusted flag set to true.
- AllowUntrusted cmd option was unused 