### PR TITLE
Fix missing Microsoft.Bcl.Hash reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.1.0-pre4](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre4) (2023-11-15)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre3...v1.1.0-pre4)
+
+**Merged pull requests:**
+
+- update moq dependency to 4.18.4 [\#61](https://github.com/microsoft/CoseSignTool/pull/61) ([JeromySt](https://github.com/JeromySt))
+
 ## [v1.1.0-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre3) (2023-11-15)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre2...v1.1.0-pre3)
@@ -35,7 +43,7 @@
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -45,13 +53,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
-
 ## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
+
+## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
 
 **Merged pull requests:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased](https://github.com/microsoft/CoseSignTool/tree/HEAD)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre5...HEAD)
+
+**Closed issues:**
+
+- CoseSignTool.exe `validate` incorrectly passes validation [\#66](https://github.com/microsoft/CoseSignTool/issues/66)
+
+## [v1.1.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre5) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre4...v1.1.0-pre5)
+
+**Merged pull requests:**
+
+- Fixing Command Line False Positives  [\#67](https://github.com/microsoft/CoseSignTool/pull/67) ([elantiguamsft](https://github.com/elantiguamsft))
+
 ## [v1.1.0-pre4](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre4) (2023-11-15)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre3...v1.1.0-pre4)

--- a/CoseHandler/CoseValidationError.cs
+++ b/CoseHandler/CoseValidationError.cs
@@ -8,28 +8,19 @@ using System.Collections.Generic;
 /// <summary>
 /// Holds information about an error in COSE validation.
 /// </summary>
-public readonly struct CoseValidationError
-{
-    /// <summary>
-    /// Creates a new CoseValidationError instance.
-    /// </summary>
-    /// <param name="errorCode">A ValidationFailureCode value that represents the error type.</param>
-    /// <param name="message">A text description of the error.</param>
-    public CoseValidationError(ValidationFailureCode errorCode)
-    {
-        ErrorCode = errorCode;
-        Message = ErrorMessages[errorCode];
-    }
+/// <param name="errorCode">A ValidationFailureCode value that represents the error type.</param>
 
+public readonly struct CoseValidationError(ValidationFailureCode errorCode)
+{
     /// <summary>
     /// Gets or sets a ValidationFailureCode value that represents the error type.
     /// </summary>
-    public ValidationFailureCode ErrorCode { get; }
+    public ValidationFailureCode ErrorCode { get; } = errorCode;
 
     /// <summary>
     /// Gets or sets a text description of the error.
     /// </summary>
-    public string Message { get; }
+    public string Message { get; } = ErrorMessages[errorCode];
 
     /// <summary>
     /// A dictionary that maps error messages to error codes.

--- a/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
+++ b/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
     <PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
   </ItemGroup>

--- a/CoseSignTool.tests/MainTests.cs
+++ b/CoseSignTool.tests/MainTests.cs
@@ -4,6 +4,7 @@
 namespace CoseSignUnitTests;
 
 using System;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using CST = CoseSignTool.CoseSignTool;
@@ -129,5 +130,19 @@ public class MainTests
         string payload = Path.GetTempFileName();
         string[] args5 = { "validate", @"/rt", payload, @"/sf", sigFile, @"/rt", "cert.wacky" };
         CST.Main(args5).Should().Be((int)ExitCode.CertificateLoadFailure);
+    }
+
+    [TestMethod]
+    public void ReturnsHelpRequestedWhenVerbMissing()
+    {
+        string[] args = Array.Empty<string>();
+        CST.Main(args).Should().Be((int)ExitCode.HelpRequested);
+    }
+
+    [TestMethod]
+    public void ReturnsHelpRequestedWhenNoOptionsAfterVerb()
+    {
+        string[] args = Array.Empty<string>();
+        CST.Main(args).Should().Be((int)ExitCode.HelpRequested);
     }
 }

--- a/CoseSignTool/CoseCommand.cs
+++ b/CoseSignTool/CoseCommand.cs
@@ -3,6 +3,9 @@
 
 namespace CoseSignTool;
 
+using System;
+using System.Text.RegularExpressions;
+
 /// <summary>
 /// A base class for console commands that handle COSE signatures.
 /// </summary>
@@ -256,11 +259,18 @@ public abstract partial class CoseCommand
     #endregion
 
     #region Usage
+
+    /// <summary>
+    /// Gets the help text for the command and merges it with the general help text for CoseSignTool.
+    /// </summary>
+    /// <returns>The merged help text.</returns>
+    public static string Usage => $"{BaseUsageString}{UsageString}";
+
     /// <summary>
     /// The first section of the command line usage. Content is generic to CoseSignTool.
+    /// Each line should have no more than 120 characters to avoid wrapping. Break is here:                            *V*
     /// </summary>
-    // The usage text to display. Each line should have no more than 120 characters to avoid wrapping. Break is here:  *V*
-    protected internal const string BaseUsageString = @$"
+    protected const string BaseUsageString = @$"
 *** CoseSignTool ***
 A tool for signing, validating, and getting payload from Cose signatures.
 
@@ -269,18 +279,18 @@ Usage:
     -- OR --
     [source program] | CoseSignTool.exe [sign | validate | get] [options]
     where [source program] pipes the first required option to CoseSignTool.
-
-Sign: Signs the specified file or piped content with a detached or embedded signature.
-Validate: Validates that the specified COSE signature file or piped signature content matches the original payload and
-    is signed with a valid certificate chain.
-Get: Retrieves and decodes the original payload from a COSE embed signed file or piped signature, writes it to a file or
-    to the console, and writes any validation errors to Standard Error.
 ";
 
     /// <summary>
     /// The end of the usage string for when no command was specified.
     /// </summary>
-    public static readonly string UsageString = $"{BaseUsageString}{Environment.NewLine}" +
-        $"To see the options for a specific command, type 'CoseSignTool [sign | validate | get] /?'";
+    protected const string UsageString = @"
+Sign: Signs the specified file or piped content with a detached or embedded signature.
+Validate: Validates that the specified COSE signature file or piped signature content matches the original payload and
+    is signed with a valid certificate chain.
+Get: Retrieves and decodes the original payload from a COSE embed signed file or piped signature, writes it to a file or
+    to the console, and writes any validation errors to Standard Error.
+
+To see the options for a specific command, type 'CoseSignTool [sign | validate | get] /?'";
     #endregion
 }

--- a/CoseSignTool/CoseSignTool.cs
+++ b/CoseSignTool/CoseSignTool.cs
@@ -3,6 +3,8 @@
 
 namespace CoseSignTool;
 
+using System.Net.NetworkInformation;
+
 /// <summary>
 /// Command line interface for COSE signing and validation operations.
 /// </summary>
@@ -24,13 +26,27 @@ public class CoseSignTool
     /// <returns>An exit code indicating success or failure.</returns>
     public static int Main(string[] args)
     {
-        var firstArg = args[0] ?? "help";
+        // Make sure we have a verb and at least one argument, and that neither of the first two arguments are help requests.
+        if (args.Length == 0 || IsNullOrHelp(args[0]) || !Enum.TryParse(args[0], ignoreCase: true, out Verb))
+        {
+            return (int)Usage(CoseCommand.Usage);
+        }
+        else if (args.Length == 1 || IsNullOrHelp(args[1]))
+        {
+            string usageString = Verb switch
+            {
+                Verbs.Sign => SignCommand.Usage,
+                Verbs.Validate => ValidateCommand.Usage,
+                Verbs.Get => GetCommand.Usage,
+                _ => CoseCommand.Usage,
+            };
+
+            return (int)Usage(usageString);
+        }
 
         try
         {
-            return Enum.TryParse(firstArg, ignoreCase: true, out Verb)
-                ? (int)RunCommand(Verb, args.Skip(1).ToArray())
-                : (int)Usage(CoseCommand.UsageString);
+            return (int)RunCommand(Verb, args.Skip(1).ToArray());
         }
         catch (Exception ex)
         {
@@ -44,6 +60,8 @@ public class CoseSignTool
             return (int)Fail(code, ex);
         }
     }
+
+    private static bool IsNullOrHelp(string arg) => arg is null || arg.EndsWith('?') || arg.EndsWith("help", StringComparison.OrdinalIgnoreCase); 
 
     /// <summary>
     /// Creates a SignCommand, ValidateCommand, or GetCommand instance based on raw command line input and then runs the command.
@@ -62,13 +80,13 @@ public class CoseSignTool
             {
                 case Verbs.Sign:
                     provider = CoseCommand.LoadCommandLineArgs(args, SignCommand.Options, out badArg);
-                    return (provider is null) ? Usage(SignCommand.UsageString, badArg) : new SignCommand(provider).Run();
+                    return (provider is null) ? Usage(SignCommand.Usage, badArg) : new SignCommand(provider).Run();
                 case Verbs.Validate:
                     provider = CoseCommand.LoadCommandLineArgs(args, ValidateCommand.Options, out badArg);
-                    return (provider is null) ? Usage(ValidateCommand.UsageString, badArg) : new ValidateCommand(provider).Run();
+                    return (provider is null) ? Usage(ValidateCommand.Usage, badArg) : new ValidateCommand(provider).Run();
                 case Verbs.Get:
                     provider = CoseCommand.LoadCommandLineArgs(args, GetCommand.Options, out badArg);
-                    return (provider is null) ? Usage(GetCommand.UsageString, badArg) : new GetCommand(provider).Run();
+                    return (provider is null) ? Usage(GetCommand.Usage, badArg) : new GetCommand(provider).Run();
                 default:
                     return ExitCode.InvalidArgumentValue;
             }

--- a/CoseSignTool/GetCommand.cs
+++ b/CoseSignTool/GetCommand.cs
@@ -66,8 +66,12 @@ public class GetCommand : ValidateCommand
         return result;
     }
 
+    /// <inheritdoc/>
+    public static new string Usage => $"{BaseUsageString}{UsageString}{SharedOptionsText}";
+
     // The usage text to display. Each line should have no more than 120 characters to avoid wrapping. Break is here:  *V*
-    internal static new string UsageString = $@"
+    // Shared options are inherited from ValidateCommand.
+    protected new const string UsageString = @"
 Get command: Retrieves and decodes the original payload from a COSE embed signed file or piped signature, writes it to a
     file or to the console, and writes any validation errors to Standard Error.
 
@@ -77,6 +81,5 @@ Options:
 
     SaveTo /sa: Specifies a file path to write the decoded payload content to.
         If no path is specified, output will be written to console.
-
-{OptionalsBlock}";
+";
 }

--- a/CoseSignTool/SignCommand.cs
+++ b/CoseSignTool/SignCommand.cs
@@ -6,7 +6,7 @@ namespace CoseSignTool;
 /// <summary>
 /// Signs a file with a COSE signature based on passed in command line arguments.
 /// </summary>
-public sealed class SignCommand : CoseCommand
+public class SignCommand : CoseCommand
 {
     /// <summary>
     /// A map of command line options to their abbreviated aliases.
@@ -219,11 +219,14 @@ public sealed class SignCommand : CoseCommand
         return cert;
     }
 
+    /// <inheritdoc/>
+    public static new string Usage => $"{BaseUsageString}{UsageString}";
+
     /// <summary>
     /// Command line usage specific to the SignInternal command.
+    /// Each line should have no more than 120 characters to avoid wrapping. Break is here:                            *V*
     /// </summary>
-    // The usage text to display. Each line should have no more than 120 characters to avoid wrapping. Break is here:  *V*
-    public static new readonly string UsageString = @"
+    protected new const string UsageString = @"
 Sign command: Signs the specified file or piped content with a detached or embedded signature.
     A detached signature resides in a separate file and validates against the original content by hash match.
     An embedded signature contains an encoded copy of the original payload. Not supported for payload of >2gb in size.
@@ -239,9 +242,9 @@ Options:
 
         PfxCertificate / pfx: A path to a private key certificate file (.pfx) to sign with.
 
-        Password / pw: Optional. The password for the .pfx file if it has one.
+        Password / pw: Optional. The password for the .pfx file if it has one. (Strongly recommended!)
 
-        --OR--
+    --OR--
 
         Thumbprint / th: The SHA1 thumbprint of a certificate in the local certificate store to sign the file with.
             Use the optional StoreName and StoreLocation parameters to tell CoseSignTool where to find the matching

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -208,8 +208,11 @@ public class ValidateCommand : CoseCommand
         return rootCerts;
     }
 
+    /// <inheritdoc/>
+    public static new string Usage => $"{BaseUsageString}{UsageString}{SharedOptionsText}";
+
     // The usage text to display. Each line should have no more than 120 characters to avoid wrapping. Break is here:  *V*
-    internal static new string UsageString = $@"
+    protected new const string UsageString = @"
 Validate command: Validates that the specified COSE signature file or piped signature content matches the original
     payload and is signed with a valid certificate chain.
 
@@ -219,12 +222,11 @@ Options:
 
     PayloadFile / payload / p: Required for detached signatures. The original source file that was signed.
         Do not use for embedded signatures.
+";
 
-{OptionalsBlock}";
-
-    protected static readonly string OptionalsBlock = $@"
-    Roots / rt: Optional. A comma-separated list of public key certificate files (.cer or .p7b), enclosed in quote marks,
-        to try to chain the signing certificate to.
+    protected const string SharedOptionsText = $@"
+    Roots / rt: Optional. A comma-separated list of public key certificate files (.cer or .p7b), enclosed in quote
+        marks, to try to chain the signing certificate to.
         CoseSignTool will try to chain to installed roots first, then user-supplied roots.
         If the COSE signature is signed with a self-signed certificate, that certificate must either be installed on and
         trusted by the machine or supplied as a root to pass validation.


### PR DESCRIPTION
The CoseSign1 libraries were originally built for .NET Standard 2.1 and later downgraded to 2.0 for compatibility. Microsoft.Bcl.Hash is included in 2.1 but not 2.0, so with the downgrade, certain validation scenarios started to fail because they couldn't find Microsoft.Bcl.Hash. This PR adds the assembly as a dependence of CoseSign1.Abstractions, which fixes the broken scenario. 
It also fixes some usage text that was appearing incorrectly, or in some cases not being displayed at all.