### PR TITLE
Revert use of primary constructor for CoseValidationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 ## [Unreleased](https://github.com/microsoft/CoseSignTool/tree/HEAD)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre5...HEAD)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...HEAD)
+
+**Closed issues:**
+
+- Running the CoseSignTool without any arguments hits an exception rather than printing the helptext [\#65](https://github.com/microsoft/CoseSignTool/issues/65)
+
+## [v1.1.0-pre6](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre6) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre5...v1.1.0-pre6)
 
 **Closed issues:**
 
 - CoseSignTool.exe `validate` incorrectly passes validation [\#66](https://github.com/microsoft/CoseSignTool/issues/66)
+
+**Merged pull requests:**
+
+- Fix missing Microsoft.Bcl.Hash reference [\#68](https://github.com/microsoft/CoseSignTool/pull/68) ([lemccomb](https://github.com/lemccomb))
 
 ## [v1.1.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre5) (2024-01-12)
 

--- a/CoseHandler/CoseValidationError.cs
+++ b/CoseHandler/CoseValidationError.cs
@@ -8,19 +8,28 @@ using System.Collections.Generic;
 /// <summary>
 /// Holds information about an error in COSE validation.
 /// </summary>
-/// <param name="errorCode">A ValidationFailureCode value that represents the error type.</param>
-
-public readonly struct CoseValidationError(ValidationFailureCode errorCode)
+public readonly struct CoseValidationError
 {
+    /// <summary>
+    /// Creates a new CoseValidationError instance.
+    /// </summary>
+    /// <param name="errorCode">A ValidationFailureCode value that represents the error type.</param>
+    /// <param name="message">A text description of the error.</param>
+    public CoseValidationError(ValidationFailureCode errorCode)
+    {
+        ErrorCode = errorCode;
+        Message = ErrorMessages[errorCode];
+    }
+
     /// <summary>
     /// Gets or sets a ValidationFailureCode value that represents the error type.
     /// </summary>
-    public ValidationFailureCode ErrorCode { get; } = errorCode;
+    public ValidationFailureCode ErrorCode { get; }
 
     /// <summary>
     /// Gets or sets a text description of the error.
     /// </summary>
-    public string Message { get; } = ErrorMessages[errorCode];
+    public string Message { get; }
 
     /// <summary>
     /// A dictionary that maps error messages to error codes.
@@ -32,12 +41,10 @@ public readonly struct CoseValidationError(ValidationFailureCode errorCode)
         { ValidationFailureCode.NoPublicKey, "No public key could be found for the signing certificate."},
         { ValidationFailureCode.CertificateChainUnreadable, "One or more certificates in the certificate chain could not be read."},
         { ValidationFailureCode.CertificateChainInvalid, "Certificate chain validation failed." },
-        { ValidationFailureCode.TrustValidationFailed, "The signature failed to validate against the trust validator." },
         { ValidationFailureCode.PayloadMismatch, "The supplied or embedded payload does not match the hash of the payload that was signed." },
         { ValidationFailureCode.PayloadMissing, "The detached signature could not be validated because the original payload was nut supplied."},
         { ValidationFailureCode.PayloadUnreadable, "The payload content could not be read."},
         { ValidationFailureCode.RedundantPayload, "The embedded signature was not validated because external payload was also specified."},
         { ValidationFailureCode.CoseHeadersInvalid, "The COSE headers in the signature could not be read." },
-        { ValidationFailureCode.Unknown, "An unknown error was thrown." }
     };
 }

--- a/CoseHandler/CoseValidationError.cs
+++ b/CoseHandler/CoseValidationError.cs
@@ -41,10 +41,12 @@ public readonly struct CoseValidationError
         { ValidationFailureCode.NoPublicKey, "No public key could be found for the signing certificate."},
         { ValidationFailureCode.CertificateChainUnreadable, "One or more certificates in the certificate chain could not be read."},
         { ValidationFailureCode.CertificateChainInvalid, "Certificate chain validation failed." },
+        { ValidationFailureCode.TrustValidationFailed, "The signature failed to validate against the trust validator." },
         { ValidationFailureCode.PayloadMismatch, "The supplied or embedded payload does not match the hash of the payload that was signed." },
         { ValidationFailureCode.PayloadMissing, "The detached signature could not be validated because the original payload was nut supplied."},
         { ValidationFailureCode.PayloadUnreadable, "The payload content could not be read."},
         { ValidationFailureCode.RedundantPayload, "The embedded signature was not validated because external payload was also specified."},
         { ValidationFailureCode.CoseHeadersInvalid, "The COSE headers in the signature could not be read." },
+        { ValidationFailureCode.Unknown, "An unknown error was thrown." }
     };
 }

--- a/CoseSignTool/CoseSignTool.cs
+++ b/CoseSignTool/CoseSignTool.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 namespace CoseSignTool;
-
-using System.Net.NetworkInformation;
-
 /// <summary>
 /// Command line interface for COSE signing and validation operations.
 /// </summary>


### PR DESCRIPTION
Reverting because the primary structure feature is not supported on all frameworks that support .NET Standard 2.0