### PR TITLE
Adding Validation Option to Output Certificate Chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.2-pre1)
+
+## [v1.1.3](https://github.com/microsoft/CoseSignTool/tree/v1.1.3) (2024-01-24)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.3)
+
+**Merged pull requests:**
+
+- Updating snk for internal package compatibility [\#72](https://github.com/microsoft/CoseSignTool/pull/72) ([elantiguamsft](https://github.com/elantiguamsft))
+
 ## [v1.1.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre2) (2024-01-18)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.1-pre2)
@@ -83,7 +95,7 @@
 
 ## [v1.1.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre1) (2023-11-03)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v1.1.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0-pre1)
 
 **Merged pull requests:**
 
@@ -93,13 +105,13 @@
 - DetachedSignatureFactory accepts pre-hashed content as payload [\#53](https://github.com/microsoft/CoseSignTool/pull/53) ([elantiguamsft](https://github.com/elantiguamsft))
 - Add password support for certificate files [\#52](https://github.com/microsoft/CoseSignTool/pull/52) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0)
-
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v0.3.1-pre.10)
+
+## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v1.1.0)
 
 **Merged pull requests:**
 

--- a/CoseHandler/ValidationResult.cs
+++ b/CoseHandler/ValidationResult.cs
@@ -81,7 +81,7 @@ public struct ValidationResult
             certDetails += $"Certificate chain details:{newline}";
             foreach (var cert in CertificateChain)
             {
-                certDetails += $"Subject Distinguished Name: {cert.Subject}{newline}" +
+                certDetails += $"{newline}Subject Distinguished Name: {cert.Subject}{newline}" +
                                $"Thumbprint: {cert.Thumbprint}{newline}" +
                                $"Serial Number: {cert.SerialNumber}{newline}" +
                                $"Issuer: {cert.Issuer}{newline}" +
@@ -90,15 +90,11 @@ public struct ValidationResult
             }
         }
 
-        string resultMessage;
-
         if (Success)
         {
             // Print success. If verbose, include any chain validation messages.
-            resultMessage = (verbose && InnerResults != null) ? $"Validation succeeded.{newline}{string.Join(newline, InnerResults.Select(r => r.ResultMessage))}" :
-                $"Validation succeeded.";
-
-            return resultMessage + newline + certDetails;
+            return ((verbose && InnerResults != null) ? $"Validation succeeded.{newline}{string.Join(newline, InnerResults.Select(r => r.ResultMessage))}" :
+                $"Validation succeeded.") + $"{newline}{certDetails}";
         }
 
         // Validation failed, so build the error text.
@@ -127,13 +123,13 @@ public struct ValidationResult
                 .Distinct();
 
         // Now filter them down to just chain status errors.
-        var certChainErrors = allIncludes?.Cast<X509ChainStatus>().Where(f => f.Status != X509ChainStatusFlags.NoError).ToList();
+        var certChainErrors = allIncludes?.Where(s => s.GetType() == typeof(X509ChainStatus)).Cast<X509ChainStatus>().Where(f => f.Status != X509ChainStatusFlags.NoError).ToList();
         string certChainBlock =
             certChainErrors?.Count > 0 ? $"Certificate chain status:{newline}{string.Join(newline + tab, certChainErrors.Select(c => c.StatusInformation))}" :
             string.Empty;
 
         // Do the same for exceptions.
-        List<Exception>? innerExceptions = allIncludes?.Cast<Exception>().ToList();
+        List<Exception>? innerExceptions = allIncludes?.Where(e => e.GetType() == typeof(Exception)).Cast<Exception>().ToList();
         string exceptionBlock =
             innerExceptions?.Count > 0 ? $"Exceptions:{newline}{string.Join(newline + tab, innerExceptions.Select(e => $"{e.GetType()}: {e.Message}"))}" :
             string.Empty;

--- a/CoseHandler/ValidationResult.cs
+++ b/CoseHandler/ValidationResult.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using CoseSign1.Abstractions;
 using CoseSign1.Certificates.Extensions;
 
@@ -78,16 +79,18 @@ public struct ValidationResult
         string certDetails = string.Empty;
         if (showCertDetails && CertificateChain is not null && CertificateChain.Count > 0)
         {
-            certDetails += $"Certificate chain details:{newline}";
+            StringBuilder certDetailsBuilder = new($"Certificate chain details:{newline}");
             foreach (var cert in CertificateChain)
             {
-                certDetails += $"{newline}Subject Distinguished Name: {cert.Subject}{newline}" +
-                               $"Thumbprint: {cert.Thumbprint}{newline}" +
-                               $"Serial Number: {cert.SerialNumber}{newline}" +
-                               $"Issuer: {cert.Issuer}{newline}" +
-                               $"Not Before: {cert.NotBefore}{newline}" +
-                               $"Not After: {cert.NotAfter}{newline}";
+                certDetailsBuilder.Append($"{newline}Subject Distinguished Name: {cert.Subject}{newline}" +
+                                          $"Thumbprint: {cert.Thumbprint}{newline}" +
+                                          $"Serial Number: {cert.SerialNumber}{newline}" +
+                                          $"Issuer: {cert.Issuer}{newline}" +
+                                          $"Not Before: {cert.NotBefore}{newline}" +
+                                          $"Not After: {cert.NotAfter}{newline}");
             }
+
+            certDetails = certDetailsBuilder.ToString();
         }
 
         if (Success)

--- a/CoseHandler/ValidationResult.cs
+++ b/CoseHandler/ValidationResult.cs
@@ -78,16 +78,15 @@ public struct ValidationResult
         string certDetails = string.Empty;
         if (showCertDetails && CertificateChain is not null && CertificateChain.Count > 0)
         {
-            certDetails += $"Certificate chain details:{newline}{newline}";
+            certDetails += $"Certificate chain details:{newline}";
             foreach (var cert in CertificateChain)
             {
-                certDetails += $"{cert.Subject}{newline}" +
-                               $"{cert.Thumbprint}{newline}" +
-                               $"{cert.SerialNumber}{newline}" +
-                               $"{cert.Issuer}{newline}" +
-                               $"{cert.NotBefore}{newline}" +
-                               $"{cert.NotAfter}{newline}" +
-                               $"{cert.Extensions}{newline}{newline}";
+                certDetails += $"Subject Distinguished Name: {cert.Subject}{newline}" +
+                               $"Thumbprint: {cert.Thumbprint}{newline}" +
+                               $"Serial Number: {cert.SerialNumber}{newline}" +
+                               $"Issuer: {cert.Issuer}{newline}" +
+                               $"Not Before: {cert.NotBefore}{newline}" +
+                               $"Not After: {cert.NotAfter}{newline}";
             }
         }
 

--- a/CoseSignTool.tests/MainTests.cs
+++ b/CoseSignTool.tests/MainTests.cs
@@ -72,7 +72,7 @@ public class MainTests
 
         // validate embedded
         sigFile = PayloadFile + ".csm";
-        string[] args4 = { "validate", @"/rt", certPair, @"/sf", sigFile, "/rm", "NoCheck" };
+        string[] args4 = { "validate", @"/rt", certPair, @"/sf", sigFile, "/rm", "NoCheck", "/scd" };
         CST.Main(args4).Should().Be((int)ExitCode.Success, "Embed validation failed.");
 
         // get content

--- a/CoseSignTool.tests/ValidateCommandTests.cs
+++ b/CoseSignTool.tests/ValidateCommandTests.cs
@@ -154,7 +154,7 @@ public class ValidateCommandTests
         result.Errors.Should().ContainSingle();
         result.Errors[0].ErrorCode.Should().Be(ValidationFailureCode.TrustValidationFailed);
 
-        result.ToString(showCertDetails: true).Should().Contain("Certificate chain details");
-        Console.WriteLine(result.ToString(showCertDetails: true));
+        //result.ToString(verbose: true, showCertDetails: true).Should().Contain("Certificate chain details");
+        Console.WriteLine(result.ToString(verbose: true, showCertDetails: true));
     }
 }

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -19,6 +19,8 @@ public class ValidateCommand : CoseCommand
         ["-AllowUntrusted"] = "AllowUntrusted",
         ["-allow"] = "AllowUntrusted",
         ["-au"] = "AllowUntrusted",
+        ["-ShowCertificateDetails"] = "ShowCertificateDetails",
+        ["-scd"] = "ShowCertificateDetails",
         ["-Verbose"] = "Verbose",
         ["-v"] = "Verbose",
     };
@@ -70,6 +72,8 @@ public class ValidateCommand : CoseCommand
     /// Allows certificates without trusted roots to pass validation.
     /// </summary>
     public bool AllowUntrusted { get; set; }
+
+    public bool ShowCertificateDetails { get; set; }
 
     /// <summary>
     /// True to print more details to console on validation failures.
@@ -132,7 +136,7 @@ public class ValidateCommand : CoseCommand
                 AllowUntrusted);
 
             // Write the result to console on STDERR
-            Console.Error.WriteLine(result.ToString());
+            Console.Error.WriteLine(result.ToString(Verbose, ShowCertificateDetails));
 
             return result.Success ? ExitCode.Success
                 : result.Errors?.Count > 0 ? ErrorMap[result.Errors.FirstOrDefault().ErrorCode]
@@ -179,6 +183,7 @@ public class ValidateCommand : CoseCommand
         RevocationMode = Enum.Parse<X509RevocationMode>(revModeString, true);
         CommonName = GetOptionString(provider, nameof(CommonName));
         AllowUntrusted = GetOptionBool(provider, nameof(AllowUntrusted));
+        ShowCertificateDetails = GetOptionBool(provider, nameof(ShowCertificateDetails));
         Verbose = GetOptionBool(provider, nameof(Verbose));
         base.ApplyOptions(provider);
     }
@@ -247,6 +252,8 @@ Options:
 
     AllowUntrusted / allow / au: Optional flag. Allows validation to succeed when chaining to an arbitrary root
         certificate on the host machine without that root being trusted.
+
+    ShowCertificateDetails / scd: Optional flag. Prints the certificate chain details to the console if the certificate chain is available.
 
     Verbose / v: Optional flag. Includes certificate chain status errors and exception messages in the error output
         when validation fails.";

--- a/docs/CoseSignTool.md
+++ b/docs/CoseSignTool.md
@@ -39,6 +39,7 @@ You may also want to specify:
     * User-specified roots will be treated as "trusted" for purposes of validation.
     * Root certificates for validation do not have to include a private key, so .cer files are acceptable.
     * To supply multiple root certificates, separate the file paths with commas.
+* Certificate Details. You can use the */ShowCertificateDetails** option to print out the details of the signing certificate chain.
 * Verbosity. You can use the */Verbose** option to get more detailed output on validation failures.
 
 And in some cases:


### PR DESCRIPTION
This change prints out information about the X509CertificateChain found within the COSE message upon validation.