### PR TITLE
Command Line Validation of Indirect Signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.1.6-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.6-pre1) (2024-02-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7...v1.1.6-pre1)
+
+## [v1.1.7](https://github.com/microsoft/CoseSignTool/tree/v1.1.7) (2024-02-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6...v1.1.7)
+
+**Merged pull requests:**
+
+- Action Permission Changes [\#76](https://github.com/microsoft/CoseSignTool/pull/76) ([elantiguamsft](https://github.com/elantiguamsft))
+
 ## [v1.1.6](https://github.com/microsoft/CoseSignTool/tree/v1.1.6) (2024-02-07)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.5...v1.1.6)
@@ -58,19 +70,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
-
 ## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
+
+## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
 
 **Closed issues:**
 
@@ -127,7 +139,7 @@
 
 ## [v1.1.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre1) (2023-11-03)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v1.1.0-pre1)
 
 **Merged pull requests:**
 
@@ -137,13 +149,13 @@
 - DetachedSignatureFactory accepts pre-hashed content as payload [\#53](https://github.com/microsoft/CoseSignTool/pull/53) ([elantiguamsft](https://github.com/elantiguamsft))
 - Add password support for certificate files [\#52](https://github.com/microsoft/CoseSignTool/pull/52) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v0.3.1-pre.10)
-
 ## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v1.1.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0)
+
+## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -153,13 +165,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
-
 ## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
+
+## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
 
 **Merged pull requests:**
 

--- a/CoseHandler/ContentValidationType.cs
+++ b/CoseHandler/ContentValidationType.cs
@@ -28,5 +28,5 @@ public enum ContentValidationType
     /// Indicates validation using an indirect payload. The payload is hashed using the algorithm in the COSE message
     /// and then the payload hash is compared to the embedded content.
     /// </summary>
-    IndirectSignature = 3
+    Indirect = 3
 }

--- a/CoseHandler/ContentValidationType.cs
+++ b/CoseHandler/ContentValidationType.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseX509;
+
+/// <summary>
+/// A set of COSE content validation types. Content validation refers to the method used to validate
+/// that the payload has not been modified.
+/// </summary>
+public enum ContentValidationType
+{
+    /// <summary>
+    /// Indicates that validation on the content was not performed.
+    /// </summary>
+    ContentValidationNotPerformed = 0,
+
+    /// <summary>
+    /// Indicates validation using a detached payload. The payload is not included in the message.
+    /// </summary>
+    Detached = 1,
+
+    /// <summary>
+    /// Indicates validation using an embedded payload. The payload is included in the message.
+    /// </summary>
+    Embedded = 2,
+
+    /// <summary>
+    /// Indicates validation using an indirect payload. The payload is hashed using the algorithm in the COSE message
+    /// and then the payload hash is compared to the embedded content.
+    /// </summary>
+    IndirectSignature = 3
+}

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -597,14 +597,18 @@ public static class CoseHandler
 
         // Validate that the COSE header is formatted correctly and that the payload and hash are consistent.
         bool messageVerified = false;
+
+        // Checks for an indirect signature, where the content header contains the hash of the payload, and the algorithm is stored in the message.
+        // If this is the case, we need to make sure the external payload hash matches the hash stored in the cose message content.
         bool indirectSignature = msg.IsDetachedSignature();
         try
         {
+
             if (!payloadBytes.IsNullOrEmpty())
             {
                 if (indirectSignature)
                 {
-                    // Embedded payload
+                    // Indirect signature, hash embedded in the COSE message
                     messageVerified = (msg.VerifyEmbedded(publicKey) && msg.SignatureMatches(payloadBytes));
                 }
                 else
@@ -617,7 +621,7 @@ public static class CoseHandler
             {
                 if (indirectSignature)
                 {
-                    // Embedded payload
+                    // Indirect signature, hash embedded in the COSE message
                     messageVerified = (msg.VerifyEmbedded(publicKey) && msg.SignatureMatches(payloadStream));
                 }
                 else

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -618,7 +618,7 @@ public static class CoseHandler
                 if (indirectSignature)
                 {
                     // Embedded payload
-                    messageVerified = (msg.VerifyEmbedded(publicKey) && msg.SignatureMatches(payloadBytes));
+                    messageVerified = (msg.VerifyEmbedded(publicKey) && msg.SignatureMatches(payloadStream));
                 }
                 else
                 {

--- a/CoseHandler/CoseHandler.csproj
+++ b/CoseHandler/CoseHandler.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CoseDetachedSignature\CoseDetachedSignature.csproj" />
     <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
     <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
     <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />

--- a/CoseHandler/CoseValidationError.cs
+++ b/CoseHandler/CoseValidationError.cs
@@ -43,7 +43,7 @@ public readonly struct CoseValidationError
         { ValidationFailureCode.CertificateChainInvalid, "Certificate chain validation failed." },
         { ValidationFailureCode.TrustValidationFailed, "The signature failed to validate against the trust validator." },
         { ValidationFailureCode.PayloadMismatch, "The supplied or embedded payload does not match the hash of the payload that was signed." },
-        { ValidationFailureCode.PayloadMissing, "The detached signature could not be validated because the original payload was not supplied."},
+        { ValidationFailureCode.PayloadMissing, "The detached or indirect signature could not be validated because the external payload was not supplied."},
         { ValidationFailureCode.PayloadUnreadable, "The payload content could not be read."},
         { ValidationFailureCode.RedundantPayload, "The embedded signature was not validated because external payload was also specified."},
         { ValidationFailureCode.CoseHeadersInvalid, "The COSE headers in the signature could not be read." },

--- a/CoseHandler/ValidationFailureCode.cs
+++ b/CoseHandler/ValidationFailureCode.cs
@@ -54,7 +54,7 @@ public enum ValidationFailureCode
     PayloadUnreadable,
 
     /// <summary>
-    /// Required payload was not supplied for detached signature.
+    /// Required payload was not supplied for a detached or indirect signature.
     /// </summary>
     PayloadMissing,
 

--- a/CoseHandler/ValidationResult.cs
+++ b/CoseHandler/ValidationResult.cs
@@ -52,7 +52,7 @@ public struct ValidationResult
     public List<X509Certificate2>? CertificateChain = null;
 
     /// <summary>
-    /// Indicates which signature validation format was used.
+    /// Indicates which payload validation format was used.
     /// </summary>
     public ContentValidationType ContentValidationType { get; set; } = default;
 
@@ -101,20 +101,13 @@ public struct ValidationResult
             certDetails = certDetailsBuilder.ToString();
         }
 
-        string contentValidationTypeMsg = "Payload validation type: " + ContentValidationType switch
-        {
-            ContentValidationType.Detached => "Detached",
-            ContentValidationType.Embedded => "Embedded",
-            ContentValidationType.IndirectSignature => "Indirect Signature",
-            ContentValidationType.ContentValidationNotPerformed => "Not Performed",
-            _ => "Unknown"
-        };
+        string contentValidationTypeMsg = "Payload validation type: " + ContentValidationType.ToString();
 
         if (Success)
         {
             // Print success. If verbose, include any chain validation messages.
             return ((verbose && InnerResults != null) ? $"Validation succeeded.{newline}{string.Join(newline, InnerResults.Select(r => r.ResultMessage))}" :
-                $"Validation succeeded.") + $"{newline}{certDetails}{newline}{contentValidationTypeMsg}";
+                $"Validation succeeded.") + $"{newline}{certDetails}{newline}{contentValidationTypeMsg}{newline}";
         }
 
         // Validation failed, so build the error text.
@@ -155,6 +148,6 @@ public struct ValidationResult
             string.Empty;
 
         // Return error messages, then cert chain errors, then exception messages.
-        return $"{header}{errorBlock}{newline}{certChainBlock}{newline}{certDetails}{exceptionBlock}";
+        return $"{header}{errorBlock}{newline}{certChainBlock}{newline}{certDetails}{newline}{contentValidationTypeMsg}{newline}{exceptionBlock}";
     }
 }

--- a/CoseHandler/ValidationResult.cs
+++ b/CoseHandler/ValidationResult.cs
@@ -101,7 +101,7 @@ public struct ValidationResult
             certDetails = certDetailsBuilder.ToString();
         }
 
-        string contentValidationTypeMsg = "Payload validation type: " + ContentValidationType.ToString();
+        string contentValidationTypeMsg = "Payload validation type: " + ContentValidationType;
 
         if (Success)
         {

--- a/CoseSignTool.tests/MainTests.cs
+++ b/CoseSignTool.tests/MainTests.cs
@@ -104,6 +104,7 @@ public class MainTests
 
         redirectedErr.ToString().Should().BeEmpty("There should be no errors.");
         redirectedOut.ToString().Should().Contain("Validation succeeded.", "Validation should succeed.");
+        redirectedOut.ToString().Should().Contain("validation type: Detached", "Validation type should be detached.");
     }
 
     [TestMethod]

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -231,7 +231,7 @@ Options:
 
     SignatureFile / sigfile / sf: Required, pipeable. The file or piped stream containing the COSE signature.
 
-    PayloadFile / payload / p: Required for detached signatures. The original source file that was signed.
+    PayloadFile / payload / p: Required for detached and indirect signatures. The original source file that was signed.
         Do not use for embedded signatures.
 ";
 

--- a/docs/CoseHandler.md
+++ b/docs/CoseHandler.md
@@ -23,7 +23,7 @@ The **Validate** method validates that a COSE signature is properly constructed,
 
 You will need to specify:
 * The **signature** to validate. You can pass in your COSE signature structure as either a byte array, a stream, or a *FileInfo* object. 
-* The **payload** that was signed (for detached signatures only.) Again, you can pass it in as a byte array, a stream, or a *FileInfo*. 
+* The **payload** that was signed (for detached and indirect signatures only.) Again, you can pass it in as a byte array, a stream, or a *FileInfo*. 
 Which types you should use for signature and payload depends on your scenario.
   * Arrays and most stream types are limited to 2gb or less, so if you anticipate large payloads, either use *FileInfo*, *FileStream*, or a custom stream type that doesn't have a backing array.
   * Payloads may be more than 2gb but signatures will not, because embedded signatures use byte arrays to store the payload.

--- a/docs/CoseSignTool.md
+++ b/docs/CoseSignTool.md
@@ -32,7 +32,7 @@ The **Validate** command validates that a COSE signature is properly constructed
 
 You will need to specify:
 * What to validate. This may be a file specified with the **/SignatureFile** option or you can pipe it in on the Standard Input channel when you call CoseSignTool. Piping in the content is generally considered more secure and performant option but large streams of > 2gb in length may be truncated, depending on what operating system and command shell you use.
-* (For detached signatures only) the **/Payload** that was signed. If validating an embedded signature, skip this part.
+* (For detached and indirect signatures only) the **/Payload** that was signed. If validating an embedded signature, skip this part.
 
 You may also want to specify:
 * Some root certificates. By default, CoseSignTool will try to chain the signing certificate to whatever certificates are installed on the machine. If you want to chain to certificates that are not installed, use the **/Roots** option.


### PR DESCRIPTION
The command line verb `validate` does not currently support the validation of "COSE detached signatures" - a COSE signing format that I will refer from this point on as "indirect signing".

Indirect signatures, as it exists presently, constitutes an embedded COSE signature where the embedded content represents the hash of the payload. The hashing algorithm is also encoded in the message.

For indirect signatures, validation requires that the payload be hashed using the same algorithm used in the creation of the COSE message. The computed hash is then compared to the hash stored in the content header to ensure the payload has not been mutated. This pull request updates the CoseSignTool.exe `validate` verb to check if the signature is indirect, in which case the aforementioned extra hash validation steps are taken.

Currently, indirect signatures embed the hash of the payload in the content header of the COSE message, and the hash algorithm is appended to the content type. The industry standard is likely to use a similar format where both the payload hash and algorithm name are stored in the content header encoded as a cbor object. Subsequent updates will be made to respect Microsoft internal practices and industry standards as they mature.


