### PR TITLE
more granular error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased](https://github.com/microsoft/CoseSignTool/tree/HEAD)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...HEAD)
+
+**Closed issues:**
+
+- Question: How to use certificate with password? [\#82](https://github.com/microsoft/CoseSignTool/issues/82)
+
+## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
+
+## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.2)
+
+**Merged pull requests:**
+
+- Revert "Add .exe to CoseSignTool NuGet" [\#83](https://github.com/microsoft/CoseSignTool/pull/83) ([elantiguamsft](https://github.com/elantiguamsft))
+
 ## [v1.2.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.0-pre1) (2024-03-07)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.0-pre1)
@@ -70,19 +90,19 @@
 
 ## [v1.1.6](https://github.com/microsoft/CoseSignTool/tree/v1.1.6) (2024-02-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4-pre1...v1.1.6)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.5...v1.1.6)
 
 **Merged pull requests:**
 
 - Only hit iterator once [\#75](https://github.com/microsoft/CoseSignTool/pull/75) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.1.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.4-pre1) (2024-01-31)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.5...v1.1.4-pre1)
-
 ## [v1.1.5](https://github.com/microsoft/CoseSignTool/tree/v1.1.5) (2024-01-31)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.5)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4-pre1...v1.1.5)
+
+## [v1.1.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.4-pre1) (2024-01-31)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.4-pre1)
 
 **Merged pull requests:**
 

--- a/CoseSignTool.tests/CoseSignTool.tests.csproj
+++ b/CoseSignTool.tests/CoseSignTool.tests.csproj
@@ -44,4 +44,8 @@
 	    <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
 	    <ProjectReference Include="..\CoseSignTool\CoseSignTool.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="TestContent\" />
+    </ItemGroup>
 </Project>

--- a/CoseSignTool.tests/Utils.cs
+++ b/CoseSignTool.tests/Utils.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseSignTool.tests;
+using System.Text;
+
+internal static class Utils
+{
+    private static readonly byte[] Payload1Bytes = Encoding.ASCII.GetBytes("Payload1!");
+
+    internal static string GetPayloadFile()
+    {
+        string payloadFile = Path.GetTempFileName();
+        File.WriteAllBytes(payloadFile, Payload1Bytes);
+        return payloadFile;
+    }
+}

--- a/CoseSignTool/ExitCode.cs
+++ b/CoseSignTool/ExitCode.cs
@@ -76,6 +76,19 @@ public enum ExitCode
     SignatureLoadError = 1894,
 
     /// <summary>
+    /// The payload or signature file that was read had no content.
+    /// </summary>
+    EmptySourceFile = 1895,
+
+    /// <summary>
+    /// A user specified file was found but could not be read.
+    /// </summary>
+    FileUnreadable = 1896,
+
+
+
+
+    /// <summary>
     /// CoseSignTool exited with an unknown error.
     /// </summary>
     UnknownError = 1950

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -101,14 +101,18 @@ public class ValidateCommand : CoseCommand
     /// <returns>An exit code indicating success or failure.</returns>
     public override ExitCode Run()
     {
-        // Get the signature, either piped in or from file.
-        Stream signatureStream = GetStreamFromPipeOrFile(SignatureFile, nameof(SignatureFile));
+        // Get the signature as a stream, either piped in or from file.
+        ExitCode exitCode = TryGetStreamFromPipeOrFile(SignatureFile, nameof(SignatureFile), out Stream? signatureStream);
+        if (exitCode != ExitCode.Success || signatureStream is null)
+        {
+            return exitCode;
+        }
 
         // Make sure the external payload file is present if specified.
         if (PayloadFile is not null && !PayloadFile.Exists)
         {
             return CoseSignTool.Fail(
-                ExitCode.PayloadReadError,
+                ExitCode.UserSpecifiedFileNotFound,
                 new FileNotFoundException(nameof(PayloadFile)),
                 $"Could not find the external Payload file at {PayloadFile}.");
         }


### PR DESCRIPTION
Added error codes to distinguish between missing, empty, and unreadable source files, and integrated them into CoseSignTool.
Added unit tests to cover these cases.
Minor cleanup of other unit tests.