### PR TITLE
Fix license filename in nuspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,28 @@
 # Changelog
 
-## [v1.2.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.2-pre1) (2024-03-20)
+## [v1.2.3-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre3) (2024-06-01)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3...v1.2.2-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre2...v1.2.3-pre3)
+
+## [v1.2.3-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre2) (2024-05-31)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre1...v1.2.3-pre2)
+
+## [v1.2.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre1) (2024-05-31)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3...v1.2.3-pre1)
+
+**Merged pull requests:**
+
+- upgrade to .NET 8, add docs to package, add retry loop for revocation server [\#89](https://github.com/microsoft/CoseSignTool/pull/89) ([lemccomb](https://github.com/lemccomb))
 
 ## [v1.2.3](https://github.com/microsoft/CoseSignTool/tree/v1.2.3) (2024-03-20)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre2...v1.2.3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2-pre1...v1.2.3)
+
+## [v1.2.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.2-pre1) (2024-03-20)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre2...v1.2.2-pre1)
 
 **Merged pull requests:**
 
@@ -14,7 +30,7 @@
 
 ## [v1.2.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre2) (2024-03-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.1-pre2)
 
 **Closed issues:**
 
@@ -24,13 +40,13 @@
 
 - more granular error codes [\#86](https://github.com/microsoft/CoseSignTool/pull/86) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.2)
-
 ## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
+
+## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.2)
 
 **Merged pull requests:**
 
@@ -118,19 +134,19 @@
 
 ## [v1.1.5](https://github.com/microsoft/CoseSignTool/tree/v1.1.5) (2024-01-31)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.5)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.5)
 
 **Merged pull requests:**
 
 - write validation output to standard out [\#74](https://github.com/microsoft/CoseSignTool/pull/74) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.4)
-
 ## [v1.1.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.3-pre1) (2024-01-26)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.3-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.3-pre1)
+
+## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.4)
 
 **Merged pull requests:**
 
@@ -142,19 +158,19 @@
 
 ## [v1.1.3](https://github.com/microsoft/CoseSignTool/tree/v1.1.3) (2024-01-24)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.3)
 
 **Merged pull requests:**
 
 - Updating snk for internal package compatibility [\#72](https://github.com/microsoft/CoseSignTool/pull/72) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.2](https://github.com/microsoft/CoseSignTool/tree/v1.1.2) (2024-01-18)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.2)
-
 ## [v1.1.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre2) (2024-01-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre1...v1.1.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.1-pre2)
+
+## [v1.1.2](https://github.com/microsoft/CoseSignTool/tree/v1.1.2) (2024-01-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre1...v1.1.2)
 
 **Merged pull requests:**
 
@@ -162,19 +178,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
-
 ## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
+
+## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
 
 **Closed issues:**
 
@@ -247,7 +263,7 @@
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -257,13 +273,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
-
 ## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
+
+## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
 
 **Merged pull requests:**
 

--- a/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
+++ b/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
@@ -6,11 +6,10 @@
     <LangVersion>latest</LangVersion>
     <NuspecFile>../Nuspec/CoseSign1.Abstractions.nuspec</NuspecFile>
 	<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
-	<NuspecProperties>version=$(Version)</NuspecProperties>
-    <SignAssembly>True</SignAssembly>
+	<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+	<SignAssembly>True</SignAssembly>
     <DelaySign>True</DelaySign>
     <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Nuspec/CoseHandler.nuspec
+++ b/Nuspec/CoseHandler.nuspec
@@ -36,7 +36,7 @@
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />
 	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE.md" target="." />
+	<file src="..\LICENSE" target="." />
 	<file src="..\CHANGELOG.md" target="." />
 	<file src="..\CoseIndirectSignature.md" target="." />
 	<file src="..\CoseSign1.Abstractions.md" target="." />

--- a/Nuspec/CoseHandler.nuspec
+++ b/Nuspec/CoseHandler.nuspec
@@ -30,8 +30,6 @@
 	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
 	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
 	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\STYLE.md" target="Docs" />
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />

--- a/Nuspec/CoseIndirectSignature.nuspec
+++ b/Nuspec/CoseIndirectSignature.nuspec
@@ -27,8 +27,6 @@ Abstractions and classes required to manage indirect signatures via COSE Sign1 m
 	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
 	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
 	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\STYLE.md" target="Docs" />
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />

--- a/Nuspec/CoseIndirectSignature.nuspec
+++ b/Nuspec/CoseIndirectSignature.nuspec
@@ -33,7 +33,7 @@ Abstractions and classes required to manage indirect signatures via COSE Sign1 m
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />
 	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE.md" target="." />
+	<file src="..\LICENSE" target="." />
 	<file src="..\CHANGELOG.md" target="." />
 	<file src="..\CoseIndirectSignature.md" target="." />
 	<file src="..\CoseSign1.Abstractions.md" target="." />

--- a/Nuspec/CoseSign1.Abstractions.nuspec
+++ b/Nuspec/CoseSign1.Abstractions.nuspec
@@ -33,7 +33,7 @@ Abstractions required to extend or enhance Create CoseSign1 functionality.
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />
 	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE.md" target="." />
+	<file src="..\LICENSE" target="." />
 	<file src="..\CHANGELOG.md" target="." />
 	<file src="..\CoseIndirectSignature.md" target="." />
 	<file src="..\CoseSign1.Abstractions.md" target="." />

--- a/Nuspec/CoseSign1.Abstractions.nuspec
+++ b/Nuspec/CoseSign1.Abstractions.nuspec
@@ -4,6 +4,7 @@
     <id>CoseSign1.Abstractions</id>
     <version>$VersionNgt$</version>
     <authors>Microsoft</authors>
+	<owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
 Abstractions required to extend or enhance Create CoseSign1 functionality.
@@ -17,18 +18,16 @@ Abstractions required to extend or enhance Create CoseSign1 functionality.
   <files>
     <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\CoseSign1.Abstractions.dll" target="lib\netstandard2.0" />
     <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\CoseSign1.Abstractions.pdb" target="Build\symbols" />
-    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
+    <!--<file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
     <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\bsi.json" target="Build\sbom\spdx_2.2" />
     <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />
+    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />-->
 	<file src="..\docs\CoseSignTool.md" target="Docs" />
 	<file src="..\docs\CoseHandler.md" target="Docs" />
 	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
 	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
 	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\STYLE.md" target="Docs" />
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />

--- a/Nuspec/CoseSign1.Certificates.nuspec
+++ b/Nuspec/CoseSign1.Certificates.nuspec
@@ -34,7 +34,7 @@ Abstractions and classes required to extend or enhance Microsoft.CoseSign1.Abstr
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />
 	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE.md" target="." />
+	<file src="..\LICENSE" target="." />
 	<file src="..\CHANGELOG.md" target="." />
 	<file src="..\CoseIndirectSignature.md" target="." />
 	<file src="..\CoseSign1.Abstractions.md" target="." />

--- a/Nuspec/CoseSign1.Certificates.nuspec
+++ b/Nuspec/CoseSign1.Certificates.nuspec
@@ -28,8 +28,6 @@ Abstractions and classes required to extend or enhance Microsoft.CoseSign1.Abstr
 	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
 	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
 	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\STYLE.md" target="Docs" />
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />

--- a/Nuspec/CoseSign1.nuspec
+++ b/Nuspec/CoseSign1.nuspec
@@ -27,8 +27,6 @@ Factory Implementations required to Create CoseSign1 Message.
 	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
 	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
 	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\STYLE.md" target="Docs" />
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />

--- a/Nuspec/CoseSign1.nuspec
+++ b/Nuspec/CoseSign1.nuspec
@@ -33,7 +33,7 @@ Factory Implementations required to Create CoseSign1 Message.
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />
 	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE.md" target="." />
+	<file src="..\LICENSE" target="." />
 	<file src="..\CHANGELOG.md" target="." />
 	<file src="..\CoseIndirectSignature.md" target="." />
 	<file src="..\CoseSign1.Abstractions.md" target="." />

--- a/Nuspec/CoseSignTool.nuspec
+++ b/Nuspec/CoseSignTool.nuspec
@@ -24,8 +24,6 @@ Command line tool to sign files using COSE Sign1 message envelopes in a way that
 	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
 	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
 	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
 	<file src="..\docs\STYLE.md" target="Docs" />
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />

--- a/Nuspec/CoseSignTool.nuspec
+++ b/Nuspec/CoseSignTool.nuspec
@@ -30,7 +30,7 @@ Command line tool to sign files using COSE Sign1 message envelopes in a way that
 	<file src="..\docs\SUPPORT.md" target="Docs" />
 	<file src="..\docs\Troubleshooting.md" target="Docs" />
 	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE.md" target="." />
+	<file src="..\LICENSE" target="." />
 	<file src="..\CHANGELOG.md" target="." />
 	<file src="..\CoseIndirectSignature.md" target="." />
 	<file src="..\CoseSign1.Abstractions.md" target="." />


### PR DESCRIPTION
NuGet pack errored out on finding LICENSE.md because the LICENSE file doesn't have an extension suffix. Removed the ".md" suffix from LICENSE file references in nuspecs.