### PR TITLE
Overhaul nuget packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.2.3-pre4](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre4) (2024-06-11)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre3...v1.2.3-pre4)
+
+**Merged pull requests:**
+
+- Fix license filename in nuspecs [\#90](https://github.com/microsoft/CoseSignTool/pull/90) ([lemccomb](https://github.com/lemccomb))
+
 ## [v1.2.3-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre3) (2024-06-01)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre2...v1.2.3-pre3)
@@ -30,7 +38,7 @@
 
 ## [v1.2.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre2) (2024-03-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre2)
 
 **Closed issues:**
 
@@ -40,13 +48,13 @@
 
 - more granular error codes [\#86](https://github.com/microsoft/CoseSignTool/pull/86) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
-
 ## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.2)
+
+## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
 
 **Merged pull requests:**
 
@@ -66,15 +74,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
-
-## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
 
 ## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+
+## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.2.0)
 
 **Merged pull requests:**
 
@@ -146,19 +154,19 @@
 
 ## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.4)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.4)
 
 **Merged pull requests:**
 
 - Adding Validation Option to Output Certificate Chain [\#73](https://github.com/microsoft/CoseSignTool/pull/73) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.2-pre1)
-
 ## [v1.1.3](https://github.com/microsoft/CoseSignTool/tree/v1.1.3) (2024-01-24)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.3)
+
+## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.2-pre1)
 
 **Merged pull requests:**
 
@@ -178,19 +186,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
-
 ## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
+
+## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
 
 **Closed issues:**
 
@@ -263,7 +271,7 @@
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -273,13 +281,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
-
 ## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
+
+## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
 
 **Merged pull requests:**
 

--- a/CoseHandler/CoseHandler.csproj
+++ b/CoseHandler/CoseHandler.csproj
@@ -1,31 +1,55 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <SignAssembly>True</SignAssembly>
-    <DelaySign>True</DelaySign>
-    <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	<NuspecFile>../Nuspec/CoseHandler.nuspec</NuspecFile>
-	<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
-	<NuspecProperties>version=$(Version)</NuspecProperties>
-  </PropertyGroup>
+	<!--Build configuration-->
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
-  </ItemGroup>
+	<!--Code style and static analysis-->
+	<PropertyGroup>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
+		<Nullable>enable</Nullable>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest</AnalysisLevel>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
-    <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-    <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-    <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
-  </ItemGroup>
+	<!--Strong name signing-->
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+		<PublicSign>True</PublicSign>
+		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
 
+	<!--NuGet package configuration-->
+	<PropertyGroup>
+		<NuspecFile>../Nuspec/CoseHandler.nuspec</NuspecFile>
+		<NuspecProperties>version=$(VersionNgt)</NuspecProperties>
+		<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<!--Package references-->
+	<ItemGroup>
+		<PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+	</ItemGroup>
+
+	<!--Project references-->
+	<ItemGroup>
+		<ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
+		<ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+		<ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+	</ItemGroup>
+
+	<!--Files to include in the package-->
+	<ItemGroup>
+		<None Include="LICENSE" Pack="true" PackagePath=""/>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 </Project>

--- a/CoseIndirectSignature/CoseIndirectSignature.csproj
+++ b/CoseIndirectSignature/CoseIndirectSignature.csproj
@@ -1,28 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <NuspecFile>../Nuspec/CoseIndirectSignature.nuspec</NuspecFile>
-	<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
-	<NuspecProperties>version=$(Version)</NuspecProperties>
-    <SignAssembly>True</SignAssembly>
-    <DelaySign>True</DelaySign>
-    <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+	<!--Build configuration-->
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>
+	<!--Code style and static analysis-->
+	<PropertyGroup>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
+		<Nullable>enable</Nullable>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest</AnalysisLevel>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
-  </ItemGroup>
+	<!--Strong name signing-->
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+		<DelaySign>True</DelaySign>
+		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+
+	<!--NuGet package configuration-->
+	<PropertyGroup>
+		<NuspecFile>../Nuspec/CoseIndirectSignature.nuspec</NuspecFile>
+		<NuspecProperties>version=$(VersionNgt)</NuspecProperties>
+		<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<!--Package references-->	
+	<ItemGroup>
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+	</ItemGroup>
+
+	<!--Project references-->
+	<ItemGroup>
+		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+	</ItemGroup>
+
+	<!--Files to include in the package-->
+	<ItemGroup>
+		<None Include="LICENSE" Pack="true" PackagePath=""/>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 
 </Project>

--- a/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
+++ b/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
@@ -1,25 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <NuspecFile>../Nuspec/CoseSign1.Abstractions.nuspec</NuspecFile>
-	<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
-	<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
-	<SignAssembly>True</SignAssembly>
-    <DelaySign>True</DelaySign>
-    <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+	<!--Build configuration-->
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
-  </ItemGroup>
+	<!--Code style and static analysis-->
+	<PropertyGroup>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
+		<Nullable>enable</Nullable>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest</AnalysisLevel>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
+	<!--Strong name signing-->
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+		<PublicSign>True</PublicSign>
+		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+
+	<!--NuGet package configuration-->
+	<PropertyGroup>
+		<NuspecFile>../Nuspec/CoseSign1.Abstractions.nuspec</NuspecFile>
+		<NuspecProperties>version=$(VersionNgt)</NuspecProperties>
+		<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<!--Package references-->
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+		<PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+	</ItemGroup>
+
+	<!--Files to include in the package-->
+	<ItemGroup>
+		<None Include="LICENSE" Pack="true" PackagePath=""/>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 </Project>

--- a/CoseSign1.Certificates/CoseSign1.Certificates.csproj
+++ b/CoseSign1.Certificates/CoseSign1.Certificates.csproj
@@ -1,30 +1,53 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <NuspecFile>../Nuspec/CoseSign1.Certificates.nuspec</NuspecFile>
-	<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
-	<NuspecProperties>version=$(Version)</NuspecProperties>
-    <SignAssembly>True</SignAssembly>
-    <DelaySign>True</DelaySign>
-    <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+	<!--Build configuration-->
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
-    <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
-  </ItemGroup>
+	<!--Code style and static analysis-->
+	<PropertyGroup>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
+		<Nullable>enable</Nullable>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest</AnalysisLevel>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-  </ItemGroup>
+	<!--Strong name signing-->
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+		<PublicSign>True</PublicSign>
+		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
 
+	<!--NuGet package configuration-->
+	<PropertyGroup>
+		<NuspecFile>../Nuspec/CoseSign1.Certificates.nuspec</NuspecFile>
+		<NuspecProperties>version=$(VersionNgt)</NuspecProperties>
+		<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+	</PropertyGroup>
+	
+	<!--Package references-->
+	<ItemGroup>
+		<PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
+		<PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+	</ItemGroup>
+
+	<!--Project references-->
+	<ItemGroup>
+		<ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+	</ItemGroup>
+
+	<!--Files to include in the package-->
+	<ItemGroup>
+		<None Include="LICENSE" Pack="true" PackagePath=""/>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 </Project>

--- a/CoseSign1/CoseSign1.csproj
+++ b/CoseSign1/CoseSign1.csproj
@@ -1,29 +1,52 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <NuspecFile>../Nuspec/CoseSign1.nuspec</NuspecFile>
-	<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
-	<NuspecProperties>version=$(Version)</NuspecProperties>
-    <SignAssembly>True</SignAssembly>
-    <DelaySign>True</DelaySign>
-    <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-    <NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>latest</AnalysisLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+	<!--Build configuration-->
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
-  </ItemGroup>
+	<!--Code style and static analysis-->
+	<PropertyGroup>
+		<EnablePreviewFeatures>true</EnablePreviewFeatures>
+		<Nullable>enable</Nullable>
+		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest</AnalysisLevel>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-  </ItemGroup>
+	<!--Strong name signing-->
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+		<PublicSign>True</PublicSign>
+		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
 
+	<!--NuGet package configuration-->
+	<PropertyGroup>
+		<NuspecFile>../Nuspec/CoseSign1.nuspec</NuspecFile>
+		<NuspecProperties>version=$(VersionNgt)</NuspecProperties>
+		<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+	</PropertyGroup>
+
+	<!--Package references-->
+	<ItemGroup>
+		<PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+	</ItemGroup>
+
+	<!--Project references-->
+	<ItemGroup>
+		<ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+	</ItemGroup>
+
+	<!--Files to include in the package-->
+	<ItemGroup>
+		<None Include="LICENSE" Pack="true" PackagePath=""/>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 </Project>

--- a/CoseSignTool.sln
+++ b/CoseSignTool.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		Nuget.config = Nuget.config
 		README.md = README.md
+		SharedProperties.targets = SharedProperties.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoseSign1.Abstractions", "CoseSign1.Abstractions\CoseSign1.Abstractions.csproj", "{4E7E48ED-ED6E-4CD1-8052-36FD91EED999}"
@@ -54,11 +55,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuspecs", "Nuspecs", "{97AFB857-361D-4B32-856A-6190A6D1066C}"
 	ProjectSection(SolutionItems) = preProject
 		Nuspec\CoseHandler.nuspec = Nuspec\CoseHandler.nuspec
-		Nuspec\CoseSignTool.nuspec = Nuspec\CoseSignTool.nuspec
 		Nuspec\CoseIndirectSignature.nuspec = Nuspec\CoseIndirectSignature.nuspec
 		Nuspec\CoseSign1.Abstractions.nuspec = Nuspec\CoseSign1.Abstractions.nuspec
 		Nuspec\CoseSign1.Certificates.nuspec = Nuspec\CoseSign1.Certificates.nuspec
 		Nuspec\CoseSign1.nuspec = Nuspec\CoseSign1.nuspec
+		Nuspec\CoseSignTool.nuspec = Nuspec\CoseSignTool.nuspec
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoseIndirectSignature.Tests", "CoseIndirectSignature.Tests\CoseIndirectSignature.Tests.csproj", "{58984C00-6EA6-47ED-AF9D-717B187A168B}"

--- a/CoseSignTool/CoseSignTool.csproj
+++ b/CoseSignTool/CoseSignTool.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+	<!--Build configuration-->
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
@@ -7,34 +7,54 @@
 		<Platforms>x64;arm64</Platforms>
 	</PropertyGroup>
 
+	<!--Code style and static analysis-->
 	<PropertyGroup>
 		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<SignAssembly>True</SignAssembly>
-		<PublicSign>True</PublicSign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+		<Nullable>enable</Nullable>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<Nullable>enable</Nullable>
-		<NuspecFile>../Nuspec/CoseSignTool.nuspec</NuspecFile>
-		<NuspecProperties>version=$(Version)</NuspecProperties>
-		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
 	</PropertyGroup>
 
+	<!--Strong name signing-->
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+		<PublicSign>True</PublicSign>
+		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>		
+	</PropertyGroup>
+
+	<!--NuGet package configuration-->
+	<PropertyGroup>
+		<NuspecFile>../Nuspec/CoseSignTool.nuspec</NuspecFile>
+		<NuspecProperties>version=$(VersionNgt)</NuspecProperties>
+		<NuspecProperties>VersionNgt=$(VersionNgt)</NuspecProperties>
+		<NuspecBasePath>$(MSBuildProjectDirectory)</NuspecBasePath>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>		
+	</PropertyGroup>
+
+	<!--Internals for testing-->
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>CoseSignTool.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
 
+	<!--Package references-->
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
 	</ItemGroup>
 
+	<!--Project references-->
 	<ItemGroup>
 		<ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
 		<ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
 	</ItemGroup>
 
+	<!--Files to include in the package-->
+	<ItemGroup>
+		<None Include="LICENSE" Pack="true" PackagePath="" />
+		<None Include="readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 </Project>

--- a/Nuspec/CoseHandler.nuspec
+++ b/Nuspec/CoseHandler.nuspec
@@ -11,33 +11,20 @@
     <dependencies>
       <group targetFramework=".NETStandard2.0">
         <dependency id="CoseSign1" version="$VersionNgt$" />
-		  <dependency id="CoseSign1.Abstractions" version="$VersionNgt$" />
-		  <dependency id="CoseSign1.Certificates" version="$VersionNgt$" />
-		  <dependency id="CoseIndirectSignature" version="$VersionNgt$" />
+		<dependency id="CoseSign1.Abstractions" version="$VersionNgt$" />
+		<dependency id="CoseSign1.Certificates" version="$VersionNgt$" />
+		<dependency id="CoseIndirectSignature" version="$VersionNgt$" />
       </group>
     </dependencies>
+	<readme>ReadMe.md</readme>
+	<license type="file">LICENSE</license>
   </metadata>
   <files>
 	<file src="..\CoseHandler\bin\Release\netstandard2.0\CoseHandler.dll" target="lib\netstandard2.0" />
     <file src="..\CoseHandler\bin\Release\netstandard2.0\CoseHandler.pdb" target="Build\symbols" />
-	<file src="..\CoseHandler\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
-	<file src="..\CoseHandler\bin\Release\netstandard2.0\_manifest\spdx_2.2\bsi.json" target="Build\sbom\spdx_2.2" />
-	<file src="..\CoseHandler\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json" target="Build\sbom\spdx_2.2" />
-	<file src="..\CoseHandler\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />
-	<file src="..\docs\CoseSignTool.md" target="Docs" />
-	<file src="..\docs\CoseHandler.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
-	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
-	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\STYLE.md" target="Docs" />
-	<file src="..\docs\SUPPORT.md" target="Docs" />
-	<file src="..\docs\Troubleshooting.md" target="Docs" />
-	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE" target="." />
-	<file src="..\CHANGELOG.md" target="." />
-	<file src="..\CoseIndirectSignature.md" target="." />
-	<file src="..\CoseSign1.Abstractions.md" target="." />
-	<file src="..\CoseSign1.Certificates.md" target="." />
+	<file src="..\CoseHandler\bin\Release\netstandard2.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\docs\*.md" target="Docs" />
+	<file src="..\*.md" target="." />
+	<file src="..\LICENSE*" target="." />
   </files>
 </package>

--- a/Nuspec/CoseIndirectSignature.nuspec
+++ b/Nuspec/CoseIndirectSignature.nuspec
@@ -13,28 +13,15 @@ Abstractions and classes required to manage indirect signatures via COSE Sign1 m
         <dependency id="CoseSign1" version="$VersionNgt$" />
       </group>
     </dependencies>
+	<readme>ReadMe.md</readme>
+	<license type="file">LICENSE</license>
   </metadata>
   <files>
     <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\CoseIndirectSignature.dll" target="lib\netstandard2.0" />
     <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\CoseIndirectSignature.pdb" target="Build\symbols" />
-    <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\_manifest\spdx_2.2\bsi.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />
-	<file src="..\docs\CoseSignTool.md" target="Docs" />
-	<file src="..\docs\CoseHandler.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
-	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
-	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\STYLE.md" target="Docs" />
-	<file src="..\docs\SUPPORT.md" target="Docs" />
-	<file src="..\docs\Troubleshooting.md" target="Docs" />
-	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE" target="." />
-	<file src="..\CHANGELOG.md" target="." />
-	<file src="..\CoseIndirectSignature.md" target="." />
-	<file src="..\CoseSign1.Abstractions.md" target="." />
-	<file src="..\CoseSign1.Certificates.md" target="." />
+    <file src="..\CoseIndirectSignature\bin\Release\netstandard2.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\docs\*.md" target="Docs" />
+	<file src="..\*.md" target="." />
+	<file src="..\LICENSE*" target="." />
   </files>
 </package>

--- a/Nuspec/CoseSign1.Abstractions.nuspec
+++ b/Nuspec/CoseSign1.Abstractions.nuspec
@@ -14,28 +14,15 @@ Abstractions required to extend or enhance Create CoseSign1 functionality.
         <dependency id="System.Security.Cryptography.Cose" version="7.0.0" />
       </group>
     </dependencies>
+	<readme>ReadMe.md</readme>
+	<license type="file">LICENSE</license>
   </metadata>
   <files>
     <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\CoseSign1.Abstractions.dll" target="lib\netstandard2.0" />
     <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\CoseSign1.Abstractions.pdb" target="Build\symbols" />
-    <!--<file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\bsi.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />-->
-	<file src="..\docs\CoseSignTool.md" target="Docs" />
-	<file src="..\docs\CoseHandler.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
-	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
-	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\STYLE.md" target="Docs" />
-	<file src="..\docs\SUPPORT.md" target="Docs" />
-	<file src="..\docs\Troubleshooting.md" target="Docs" />
-	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE" target="." />
-	<file src="..\CHANGELOG.md" target="." />
-	<file src="..\CoseIndirectSignature.md" target="." />
-	<file src="..\CoseSign1.Abstractions.md" target="." />
-	<file src="..\CoseSign1.Certificates.md" target="." />
+    <file src="..\CoseSign1.Abstractions\bin\Release\netstandard2.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\docs\*.md" target="Docs" />
+	<file src="..\*.md" target="." />
+	<file src="..\LICENSE*" target="." />
   </files>
 </package>

--- a/Nuspec/CoseSign1.Certificates.nuspec
+++ b/Nuspec/CoseSign1.Certificates.nuspec
@@ -14,28 +14,15 @@ Abstractions and classes required to extend or enhance Microsoft.CoseSign1.Abstr
         <dependency id="CoseSign1.Abstractions" version="$VersionNgt$" />
       </group>
     </dependencies>
+	<readme>ReadMe.md</readme>
+	<license type="file">LICENSE</license>
   </metadata>
   <files>
     <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\CoseSign1.Certificates.dll" target="lib\netstandard2.0" />
     <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\CoseSign1.Certificates.pdb" target="Build\symbols" />
-    <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\_manifest\spdx_2.2\bsi.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json" target="Build\sbom\spdx_2.2" />
-    <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />
-	<file src="..\docs\CoseSignTool.md" target="Docs" />
-	<file src="..\docs\CoseHandler.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
-	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
-	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\STYLE.md" target="Docs" />
-	<file src="..\docs\SUPPORT.md" target="Docs" />
-	<file src="..\docs\Troubleshooting.md" target="Docs" />
-	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE" target="." />
-	<file src="..\CHANGELOG.md" target="." />
-	<file src="..\CoseIndirectSignature.md" target="." />
-	<file src="..\CoseSign1.Abstractions.md" target="." />
-	<file src="..\CoseSign1.Certificates.md" target="." />
+    <file src="..\CoseSign1.Certificates\bin\Release\netstandard2.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\docs\*.md" target="Docs" />
+	<file src="..\*.md" target="." />
+	<file src="..\LICENSE*" target="." />
   </files>
 </package>

--- a/Nuspec/CoseSign1.nuspec
+++ b/Nuspec/CoseSign1.nuspec
@@ -12,29 +12,17 @@ Factory Implementations required to Create CoseSign1 Message.
       <group targetFramework=".NETStandard2.0">
         <dependency id="CoseSign1.Abstractions" version="$VersionNgt$" />
       </group>
+      <group targetFramework=".net8.0"></group>
     </dependencies>
+	<readme>ReadMe.md</readme>
+	<license type="file">LICENSE</license>
   </metadata>
   <files>
     <file src="..\CoseSign1\bin\Release\netstandard2.0\CoseSign1.dll" target="lib\netstandard2.0" />
     <file src="..\CoseSign1\bin\Release\netstandard2.0\CoseSign1.pdb" target="Build\symbols" />
-	<file src="..\CoseSign1\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.cat" target="Build\sbom\spdx_2.2" />
-	<file src="..\CoseSign1\bin\Release\netstandard2.0\_manifest\spdx_2.2\bsi.json" target="Build\sbom\spdx_2.2" />
-	<file src="..\CoseSign1\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json" target="Build\sbom\spdx_2.2" />
-	<file src="..\CoseSign1\bin\Release\netstandard2.0\_manifest\spdx_2.2\manifest.spdx.json.sha256" target="Build\sbom\spdx_2.2" />
-	<file src="..\docs\CoseSignTool.md" target="Docs" />
-	<file src="..\docs\CoseHandler.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
-	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
-	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\STYLE.md" target="Docs" />
-	<file src="..\docs\SUPPORT.md" target="Docs" />
-	<file src="..\docs\Troubleshooting.md" target="Docs" />
-	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE" target="." />
-	<file src="..\CHANGELOG.md" target="." />
-	<file src="..\CoseIndirectSignature.md" target="." />
-	<file src="..\CoseSign1.Abstractions.md" target="." />
-	<file src="..\CoseSign1.Certificates.md" target="." />
+	<file src="..\CoseSign1\bin\Release\netstandard2.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\docs\*.md" target="Docs" />
+	<file src="..\*.md" target="." />
+	<file src="..\LICENSE*" target="." />
   </files>
 </package>

--- a/Nuspec/CoseSignTool.nuspec
+++ b/Nuspec/CoseSignTool.nuspec
@@ -9,29 +9,20 @@
 Command line tool to sign files using COSE Sign1 message envelopes in a way that is compatible with Supply Chain Integrity Transparency and Trust (SCITT).
     </description>
     <dependencies>
-      <group targetFramework=".NETStandard2.0">
-		  <dependency id="CoseHandler" version="$VersionNgt$" />
-      </group>
-    </dependencies>
+		<group targetFramework=".NET8.0">
+			<dependency id="CoseHandler" version="$VersionNgt$" />
+		</group>
+	</dependencies>
+	<readme>ReadMe.md</readme>
+	<license type="file">LICENSE</license>
   </metadata>
   <files>
-	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.exe" target="lib\netstandard2.0" />
-	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.dll" target="lib\netstandard2.0" />
+	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.exe" target="lib\net8.0" />
+	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.dll" target="lib\net8.0" />
 	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.pdb" target="Build\symbols" />
-	<file src="..\docs\CoseSignTool.md" target="Docs" />
-	<file src="..\docs\CoseHandler.md" target="Docs" />
-	<file src="..\docs\Advanced.md" target="Docs" />
-	<file src="..\docs\CODE_OF_CONDUCT.md" target="Docs" />
-	<file src="..\docs\CONTRIBUTING.md" target="Docs" />
-	<file src="..\docs\SECURITY.md" target="Docs" />
-	<file src="..\docs\STYLE.md" target="Docs" />
-	<file src="..\docs\SUPPORT.md" target="Docs" />
-	<file src="..\docs\Troubleshooting.md" target="Docs" />
-	<file src="..\ReadMe.md" target="." />
-	<file src="..\LICENSE" target="." />
-	<file src="..\CHANGELOG.md" target="." />
-	<file src="..\CoseIndirectSignature.md" target="." />
-	<file src="..\CoseSign1.Abstractions.md" target="." />
-	<file src="..\CoseSign1.Certificates.md" target="." />
+	<file src="..\CoseSignTool\bin\x64\Release\net8.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\docs\*.md" target="Docs" />
+	<file src="..\*.md" target="." />
+	<file src="..\LICENSE*" target="." />
   </files>
 </package>


### PR DESCRIPTION
Modified the .nuspec and .csproj files to ensure that all of the newly included files appear where they should in the package, and that the pack operation succeeds. Declared the license and readme files so they are visible from the Nuget interface. 
Rearranged the project files for better consistency and readability.