### PR TITLE
Adjusted file paths in CoseSignTool.nuspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.2.3-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre5) (2024-06-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre4...v1.2.3-pre5)
+
+**Merged pull requests:**
+
+- Overhaul nuget packaging [\#91](https://github.com/microsoft/CoseSignTool/pull/91) ([lemccomb](https://github.com/lemccomb))
+
 ## [v1.2.3-pre4](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre4) (2024-06-11)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre3...v1.2.3-pre4)
@@ -74,15 +82,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
-
-## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
 
 ## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+
+## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.1.8-pre1)
 
 **Merged pull requests:**
 
@@ -186,19 +194,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
-
 ## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
+
+## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
 
 **Closed issues:**
 
@@ -271,7 +279,7 @@
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -281,13 +289,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
-
 ## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
+
+## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
 
 **Merged pull requests:**
 

--- a/Nuspec/CoseSignTool.nuspec
+++ b/Nuspec/CoseSignTool.nuspec
@@ -17,10 +17,10 @@ Command line tool to sign files using COSE Sign1 message envelopes in a way that
 	<license type="file">LICENSE</license>
   </metadata>
   <files>
-	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.exe" target="lib\net8.0" />
-	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.dll" target="lib\net8.0" />
-	<file src="..\CoseSignTool\bin\x64\Release\net8.0\CoseSignTool.pdb" target="Build\symbols" />
-	<file src="..\CoseSignTool\bin\x64\Release\net8.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
+	<file src="..\CoseSignTool\bin\Release\net8.0\CoseSignTool.exe" target="lib\net8.0" />
+	<file src="..\CoseSignTool\bin\Release\net8.0\CoseSignTool.dll" target="lib\net8.0" />
+	<file src="..\CoseSignTool\bin\Release\net8.0\CoseSignTool.pdb" target="Build\symbols" />
+	<file src="..\CoseSignTool\bin\Release\net8.0\_manifest\spdx_2.2\*.*" target="Build\sbom\spdx_2.2" />
 	<file src="..\docs\*.md" target="Docs" />
 	<file src="..\*.md" target="." />
 	<file src="..\LICENSE*" target="." />


### PR DESCRIPTION
Removing the "x64" from the file paths in CoseSignTool.nuspec