### PR TITLE
Allow outdated and cert chain bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+
+## [v1.2.6-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.6-pre1) (2024-08-26)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.6...v1.2.6-pre1)
+
+**Merged pull requests:**
+
+- rerelease workflow [\#108](https://github.com/microsoft/CoseSignTool/pull/108) ([lemccomb](https://github.com/lemccomb))
+- Fix rerelease workflow again [\#107](https://github.com/microsoft/CoseSignTool/pull/107) ([lemccomb](https://github.com/lemccomb))
+- User/lemccomb/re release workflow3 [\#106](https://github.com/microsoft/CoseSignTool/pull/106) ([lemccomb](https://github.com/lemccomb))
+- experiment [\#104](https://github.com/microsoft/CoseSignTool/pull/104) ([lemccomb](https://github.com/lemccomb))
+- Create rerelease.yml [\#103](https://github.com/microsoft/CoseSignTool/pull/103) ([lemccomb](https://github.com/lemccomb))
+- Fix slashes [\#102](https://github.com/microsoft/CoseSignTool/pull/102) ([lemccomb](https://github.com/lemccomb))
+- Publish self-contained [\#101](https://github.com/microsoft/CoseSignTool/pull/101) ([lemccomb](https://github.com/lemccomb))
+
 ## [v1.2.6](https://github.com/microsoft/CoseSignTool/tree/v1.2.6) (2024-08-19)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.5-pre2...v1.2.6)
@@ -97,19 +112,19 @@
 
 ## [v1.2.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre1) (2024-05-31)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2-pre1...v1.2.3-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3...v1.2.3-pre1)
 
 **Merged pull requests:**
 
 - upgrade to .NET 8, add docs to package, add retry loop for revocation server [\#89](https://github.com/microsoft/CoseSignTool/pull/89) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.2-pre1) (2024-03-20)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3...v1.2.2-pre1)
-
 ## [v1.2.3](https://github.com/microsoft/CoseSignTool/tree/v1.2.3) (2024-03-20)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre2...v1.2.3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2-pre1...v1.2.3)
+
+## [v1.2.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.2-pre1) (2024-03-20)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre2...v1.2.2-pre1)
 
 **Merged pull requests:**
 
@@ -133,19 +148,19 @@
 
 ## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.1-pre1)
 
 **Merged pull requests:**
 
 - Revert "Add .exe to CoseSignTool NuGet" [\#83](https://github.com/microsoft/CoseSignTool/pull/83) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.2.1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1) (2024-03-07)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.1)
-
 ## [v1.2.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.0-pre1) (2024-03-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.exeTest...v1.2.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.0-pre1)
+
+## [v1.2.1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1) (2024-03-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.exeTest...v1.2.1)
 
 **Merged pull requests:**
 
@@ -153,15 +168,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
-
-## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
 
 ## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7-pre3...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+
+## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7-pre3...v1.2.0)
 
 **Merged pull requests:**
 
@@ -221,19 +236,19 @@
 
 ## [v1.1.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.4-pre1) (2024-01-31)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.4-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.4-pre1)
 
 **Merged pull requests:**
 
 - write validation output to standard out [\#74](https://github.com/microsoft/CoseSignTool/pull/74) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.4)
-
 ## [v1.1.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.3-pre1) (2024-01-26)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.3-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.3-pre1)
+
+## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.4)
 
 **Merged pull requests:**
 
@@ -265,19 +280,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
-
 ## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
+
+## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
 
 **Closed issues:**
 

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -330,6 +330,8 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     /// <exception cref="CoseValidationException">The exception thrown if validation failed</exception>
     public static ValidationResult Validate(
         byte[] signature,
@@ -337,8 +339,9 @@ public static class CoseHandler
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
         string? requiredCommonName = null,
-        bool allowUntrusted = false)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated), payload);
 
     /// <summary>
     /// Validates a detached COSE signature in memory.
@@ -348,14 +351,17 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     public static ValidationResult Validate(
         byte[] signature,
         Stream payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
         string? requiredCommonName = null,
-        bool allowUntrusted = false)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated), payload);
 
     /// <summary>
     /// Validates a detached or embedded COSE signature in memory.
@@ -365,14 +371,17 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     public static ValidationResult Validate(
         Stream signature,
         byte[]? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
         string? requiredCommonName = null,
-        bool allowUntrusted = false)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated), payload);
 
     /// <summary>
     /// Validates a COSE signature file.
@@ -382,16 +391,19 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     public static ValidationResult Validate(
         FileInfo signature,
         FileInfo? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
         string? requiredCommonName = null,
-        bool allowUntrusted = false)
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
         => ValidateInternal(signatureBytes: null, signatureStream: null, signatureFile: signature,
             payloadBytes: null, payloadStream: null, payloadFile: payload, out _,
-            GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted));
+            GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated));
 
     /// <summary>
     /// Validates a detached COSE signature in memory.
@@ -401,14 +413,17 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     public static ValidationResult Validate(
         Stream signature,
         Stream? payload,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
         string? requiredCommonName = null,
-        bool allowUntrusted = false)
-        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted), payload);
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
+        => Validate(signature, GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated), payload);
 
     /// <summary>
     /// Validates a detached or embedded COSE signature in  memory.
@@ -484,15 +499,19 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to during validation, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     /// <returns>The decoded payload as a string.</returns>
     public static string? GetPayload(
         byte[] signature,
         out ValidationResult result,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
+        string? requiredCommonName = null,
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
         => GetPayload(signature,
-            GetValidator(roots, revocationMode, requiredCommonName),
+            GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated),
             out result);
 
     /// <summary>
@@ -503,15 +522,19 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to during validation, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     /// <returns>The decoded payload as a string.</returns>
     public static string? GetPayload(
         Stream signature,
         out ValidationResult result,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
+        string? requiredCommonName = null,
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
         => GetPayload(signature,
-            GetValidator(roots, revocationMode, requiredCommonName),
+            GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated),
             out result);
 
     /// <summary>
@@ -522,15 +545,19 @@ public static class CoseHandler
     /// <param name="roots">Optional. A set of root certificates to try to chain the signing certificate to during validation, in addition to the certificates installed on the host machine.</param>
     /// <param name="revocationMode">Optional. Revocation mode to use when validating the certificate chain.</param>
     /// <param name="requiredCommonName">Optional. Requires the signing certificate to match the specified Common Name.</param>
+    /// <param name="allowUntrusted">True to allow untrusted certificates.</param>
+    /// <param name="allowOutdated">True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.</param>
     /// <returns>The decoded payload as a string.</returns>
     public static string? GetPayload(
         FileInfo signature,
         out ValidationResult result,
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
-        string? requiredCommonName = null)
+        string? requiredCommonName = null,
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
         => GetPayloadInternal(signatureBytes: null, signatureStream: null, signatureFile: signature,
-            GetValidator(roots, revocationMode, requiredCommonName),
+            GetValidator(roots, revocationMode, requiredCommonName, allowUntrusted, allowOutdated),
             out result);
 
     /// <summary>
@@ -792,14 +819,16 @@ public static class CoseHandler
         List<X509Certificate2>? roots = null,
         X509RevocationMode revocationMode = X509RevocationMode.Online,
         string? requiredCommonName = null,
-        bool allowUntrusted = false)
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
     {
         // Create a validator for the certificate trust chain.
         CoseSign1MessageValidator chainTrustValidator = new X509ChainTrustValidator(
                 roots,
                 revocationMode,
                 allowUnprotected: true,
-                allowUntrusted: allowUntrusted);
+                allowUntrusted: allowUntrusted,
+                allowOutdated: allowOutdated);
 
         // If validating CommonName, we'll do that first, and set it to call for chain trust validation when it finishes.
         if (!string.IsNullOrWhiteSpace(requiredCommonName))

--- a/CoseSign1.Certificates.Tests/X509ChainTrustValidatorTests.cs
+++ b/CoseSign1.Certificates.Tests/X509ChainTrustValidatorTests.cs
@@ -221,9 +221,10 @@ public class X509ChainTrustValidatorTests
         CoseSign1Message message = CreateCoseSign1MessageWithChainedCert();
 
         // Mock the ChainBuilder to always return success
-        Mock<ICertificateChainBuilder> mockBuilder = new(MockBehavior.Strict);
+        Mock<ICertificateChainBuilder> mockBuilder = new();
         mockBuilder.Setup(x => x.Build(It.IsAny<X509Certificate2>())).Returns(true);
         mockBuilder.Setup(x => x.ChainElements).Returns([.. DefaultTestChain]);
+        mockBuilder.Setup(x => x.ChainPolicy).Returns(new X509ChainPolicy());
 
         // Validate
         X509ChainTrustValidator Validator = new(mockBuilder.Object);
@@ -302,7 +303,7 @@ public class X509ChainTrustValidatorTests
         results[0].Includes.Should().NotBeNull();
         results[0].Includes?.Count.Should().Be(1);
         X509ChainStatus? status = results[0].Includes?.Cast<X509ChainStatus>().FirstOrDefault();
-        status.Value.Status.Should().Be(X509ChainStatusFlags.PartialChain);
+        status.Value.Status.Should().Be(X509ChainStatusFlags.UntrustedRoot);
     }
 
     // Prove that an untrusted, self-signed cert passes only when the same cert is passed as a root or AllowUntrusted is ON
@@ -396,7 +397,7 @@ public class X509ChainTrustValidatorTests
         results[0].Includes.Should().NotBeNull();
         results[0].Includes?.Count.Should().Be(1);
         X509ChainStatus? status = results[0].Includes?.Cast<X509ChainStatus>().FirstOrDefault();
-        status.Value.Status.Should().Be(X509ChainStatusFlags.PartialChain);
+        status.Value.Status.Should().Be(X509ChainStatusFlags.UntrustedRoot);
 
         // Revoked cert case //
         Mock<ICertificateChainBuilder> builder = new();

--- a/CoseSign1.Certificates/Local/Validators/X509ChainTrustValidator.cs
+++ b/CoseSign1.Certificates/Local/Validators/X509ChainTrustValidator.cs
@@ -101,7 +101,6 @@ public class X509ChainTrustValidator(
         List<X509Certificate2>? certChain,
         List<X509Certificate2>? extraCertificates)
     {
-
         // If there are user-supplied roots, add them to the ExtraCerts collection.
         bool hasRoots = false;
         if (Roots?.Count > 0)
@@ -109,6 +108,16 @@ public class X509ChainTrustValidator(
             hasRoots = true;
             ChainBuilder.ChainPolicy.ExtraStore.Clear();
             Roots.ForEach(c => ChainBuilder.ChainPolicy.ExtraStore.Add(c));
+        }
+
+        if (certChain?.Count > 0)
+        {
+            ChainBuilder.ChainPolicy.ExtraStore.AddRange(certChain.ToArray());
+        }
+
+        if (extraCertificates?.Count > 0)
+        {
+            ChainBuilder.ChainPolicy.ExtraStore.AddRange(extraCertificates.ToArray());
         }
 
         // Build the cert chain. If Build succeeds, return success.

--- a/CoseSign1.Tests.Common/TestCertificateUtils.cs
+++ b/CoseSign1.Tests.Common/TestCertificateUtils.cs
@@ -149,9 +149,10 @@ public static class TestCertificateUtils
         [CallerMemberName] string? testName = "none",
         bool useEcc = false,
         int? keySize = null,
-        bool leafFirst = false)
+        bool leafFirst = false,
+        TimeSpan? rootDuration = null)
     {
-        X509Certificate2 testRoot = CreateCertificate($"Test Root: {testName}", useEcc: useEcc, keySize: keySize);
+        X509Certificate2 testRoot = CreateCertificate($"Test Root: {testName}", useEcc: useEcc, keySize: keySize, duration: rootDuration);
         X509Certificate2 issuer = CreateCertificate($"Test Issuer: {testName}", testRoot, useEcc: useEcc, keySize: keySize);
         X509Certificate2 leaf = CreateCertificate($"Test Leaf: {testName}", issuer, useEcc: useEcc, keySize: keySize);
 

--- a/CoseSignTool.Tests/ValidateCommandTests.cs
+++ b/CoseSignTool.Tests/ValidateCommandTests.cs
@@ -72,7 +72,7 @@ public class ValidateCommandTests
 
         // The expired message seems to differ between Windows and Linux
         (result.ToString(true, true).Contains("A required certificate is not within its validity period") ||
-            result.ToString(true, true).Contains("A required certificate is not within its validity period"))
+            result.ToString(true, true).Contains("An expired certificate was detected."))
             .Should().BeTrue(result.ToString(true, true));
     }
 

--- a/CoseSignTool.Tests/ValidateCommandTests.cs
+++ b/CoseSignTool.Tests/ValidateCommandTests.cs
@@ -72,7 +72,7 @@ public class ValidateCommandTests
 
         // The expired message seems to differ between Windows and Linux
         (result.ToString(true, true).Contains("A required certificate is not within its validity period") ||
-            result.ToString(true, true).Contains("An expired certificate was detected."))
+            result.ToString(true, true).Contains("expired"))
             .Should().BeTrue(result.ToString(true, true));
     }
 

--- a/CoseSignTool/GetCommand.cs
+++ b/CoseSignTool/GetCommand.cs
@@ -38,10 +38,17 @@ public class GetCommand : ValidateCommand
     // This is consumed by ValidateCommand.Run, which uses it in place of the call to CoseParser.Validate.
     protected internal override ValidationResult RunCoseHandlerCommand(
         Stream signature, FileInfo? payloadFile, List<X509Certificate2>? rootCerts,
-        X509RevocationMode revocationMode, string? commonName, bool allowUntrusted)
+        X509RevocationMode revocationMode, string? commonName, bool allowUntrusted, bool allowOutdated)
     {
         // Get the embedded payload content.
-        string? content = CoseHandler.GetPayload(signature, out ValidationResult result, rootCerts, revocationMode, commonName);
+        string? content = CoseHandler.GetPayload(
+            signature,
+            out ValidationResult result,
+            rootCerts,
+            revocationMode,
+            commonName,
+            allowUntrusted,
+            allowOutdated);
 
         // Write the content to the specified file, if any, or else pipe to STDOUT.
         if (content is null)

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -19,6 +19,8 @@ public class ValidateCommand : CoseCommand
         ["-AllowUntrusted"] = "AllowUntrusted",
         ["-allow"] = "AllowUntrusted",
         ["-au"] = "AllowUntrusted",
+        ["-AllowOutdated"] = "AllowOutdated",
+        ["-ao"] = "AllowOutdated",
         ["-ShowCertificateDetails"] = "ShowCertificateDetails",
         ["-scd"] = "ShowCertificateDetails",
         ["-Verbose"] = "Verbose",
@@ -73,6 +75,14 @@ public class ValidateCommand : CoseCommand
     /// </summary>
     public bool AllowUntrusted { get; set; }
 
+    /// <summary>
+    /// True to allow signatures with expired certificates to pass validation unless the expired certificate has a lifetime EKU.
+    /// </summary>
+    public bool AllowOutdated { get; set; }
+
+    /// <summary>
+    /// True to show certificate chain details
+    /// </summary>
     public bool ShowCertificateDetails { get; set; }
 
     /// <summary>
@@ -138,7 +148,8 @@ public class ValidateCommand : CoseCommand
                 rootCerts,
                 RevocationMode,
                 CommonName,
-                AllowUntrusted);
+                AllowUntrusted,
+                AllowOutdated);
 
             // Write the result to console on STDOUT
             Console.WriteLine(result.ToString(Verbose, ShowCertificateDetails));
@@ -175,14 +186,16 @@ public class ValidateCommand : CoseCommand
         List<X509Certificate2>? rootCerts,
         X509RevocationMode revocationMode,
         string? commonName = null,
-        bool allowUntrusted = false)
+        bool allowUntrusted = false,
+        bool allowOutdated = false)
         => CoseHandler.Validate(
             signature,
             payload?.GetStreamResilient(),
             rootCerts,
             revocationMode,
             commonName,
-            allowUntrusted);
+            allowUntrusted,
+            allowOutdated);
 
     //<inheritdoc />
     protected internal override void ApplyOptions(CommandLineConfigurationProvider provider)
@@ -192,6 +205,7 @@ public class ValidateCommand : CoseCommand
         RevocationMode = Enum.Parse<X509RevocationMode>(revModeString, true);
         CommonName = GetOptionString(provider, nameof(CommonName));
         AllowUntrusted = GetOptionBool(provider, nameof(AllowUntrusted));
+        AllowOutdated = GetOptionBool(provider, nameof(AllowOutdated));
         ShowCertificateDetails = GetOptionBool(provider, nameof(ShowCertificateDetails));
         Verbose = GetOptionBool(provider, nameof(Verbose));
         base.ApplyOptions(provider);
@@ -261,6 +275,9 @@ Options:
 
     AllowUntrusted / allow / au: Optional flag. Allows validation to succeed when chaining to an arbitrary root
         certificate on the host machine without that root being trusted.
+
+    AllowOutdated / ao: Optional flag. Allows validation to succeed when the signing certificate has expired, unless the
+        expired certificate has a lifetime EKU.
 
     ShowCertificateDetails / scd: Optional flag. Prints the certificate chain details to the console if the certificate chain is available.
 

--- a/docs/CoseSignTool.md
+++ b/docs/CoseSignTool.md
@@ -92,6 +92,7 @@ And in some cases:
 * **/RevocationMode** -- By default, CoseSignTool checks the signing certificate against an online database to see if it has been revoked. You can skip this check by setting **/RevocationMode** to **none**. RevocationMode.Offline is not yet implemented.
 * **/CommonName** -- Forces validation to require that the signing certificate match a specific Common Name value.
 * **/AllowUntrusted** -- Prevents CoseSignTool from failing validation when the certificate chain has an untrusted root. This is intended for test purposes and should not generally be used for production.
+* **/AllowOutdated** -- Prevents CoseSignTool from failing validation when the certificate chain has an expired certificate, unless the expired certificate has a lifetime EKU.
 
 Run *CoseSignTool validate /?* for the complete command line usage.
 
@@ -103,6 +104,6 @@ You will need to specify:
 
 You may also want to specify:
 * A file to write the payload to. Use the **/SaveTo** option to specify a file path; otherwise the payload will be printed to Standard Out.
-* **/Roots**, **/Verbosity**, **/RevocationMode**, **/CommonName**, and **/AllowUntrusted**, exactly as with the Validate command.
+* **/Roots**, **/Verbosity**, **/RevocationMode**, **/CommonName**, **/AllowUntrusted**, and **/AllowOutdated** exactly as with the Validate command.
 
 Run *CoseSignTool get /?* for the complete command line usage.


### PR DESCRIPTION
**Feature:** Exposing the "AllowOutdated" option to the command line tool, which enables successful validation of COSE signatures with a certificate chain containing one or more expired nodes. This option has no effect if the signing certificate has the lifetime eku (1.3.6.1.4.1.311.10.3.13).

**BugFix:** The X509ChainTrustValidator now can use all of the certificates included in the x5t header of the COSE message when attempting to build a chain of trust from the signing certificate. Previously, the validator would only use the signing certificate and certificates already installed on machine.