### PR TITLE
Online Revocation and Root Trust Bugfix

### DIFF
--- a/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
+++ b/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
@@ -37,7 +37,7 @@
 
 	<!--Package references-->
 	<ItemGroup>
-		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="8.0.0" />
 	</ItemGroup>
 
 	<!--Files to include in the package-->

--- a/CoseSign1.Certificates/CoseSign1.Certificates.csproj
+++ b/CoseSign1.Certificates/CoseSign1.Certificates.csproj
@@ -38,6 +38,7 @@
 	<!--Package references-->
 	<ItemGroup>
 		<PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
+		<PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
 	</ItemGroup>
 
 	<!--Project references-->

--- a/CoseSign1.Tests/CoseSign1.Tests.csproj
+++ b/CoseSign1.Tests/CoseSign1.Tests.csproj
@@ -32,8 +32,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
-		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+		<PackageReference Include="System.Formats.Cbor" Version="8.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="8.0.0" />
 	</ItemGroup>
 
 	<!-- Project references -->


### PR DESCRIPTION
`CoseSign1.Certificates.Local.Validators.X509ChainTrustValidator` must remain in a .NET Standard 2.0 lib to maintain compatibility with several consumers of the library. Unfortunately this means we can't use the modern net core implementations of `X509Chain` and `X509ChainPolicy`, which offers support for custom trust providers, unlike the .NET Standard versions.

Because of this limitation, we have to do some amount of post-processing of the certificate trust chain results. This PR addresses a "bug" where custom roots of trust are passed in and the `X509Chain.Build()` library method erroneously attempts to check revocation status of self-signed roots that we are explicitly pinning trust to. The intended behavior of this method is actually to skip revocation for self-signed roots with the recognition that self-attestation of revocation status provides no value. 

<img src="https://github.com/user-attachments/assets/7a2d7e0e-0b6f-4ce4-9c08-0398ee0158ed" width=20% height=20%>
