### PR TITLE
Increase timeout for checking for empty streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Changelog
 
-## [v1.2.6-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.6-pre2) (2024-09-23)
+## [v1.2.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre1) (2024-09-25)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8...v1.2.6-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre2...v1.2.8-pre1)
+
+## [v1.2.8-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre2) (2024-09-25)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8...v1.2.8-pre2)
+
+**Merged pull requests:**
+
+- Make the advanced stream handling optional. Use simple retry instead. [\#112](https://github.com/microsoft/CoseSignTool/pull/112) ([lemccomb](https://github.com/lemccomb))
 
 ## [v1.2.8](https://github.com/microsoft/CoseSignTool/tree/v1.2.8) (2024-09-23)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.6-pre1...v1.2.8)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.6-pre2...v1.2.8)
+
+## [v1.2.6-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.6-pre2) (2024-09-23)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.6-pre1...v1.2.6-pre2)
 
 **Merged pull requests:**
 
@@ -72,19 +84,19 @@
 
 ## [v1.2.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.4-pre1) (2024-07-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4...v1.2.4-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre7...v1.2.4-pre1)
 
 **Merged pull requests:**
 
 - User/lemccomb/fileread [\#94](https://github.com/microsoft/CoseSignTool/pull/94) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.4](https://github.com/microsoft/CoseSignTool/tree/v1.2.4) (2024-06-14)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre7...v1.2.4)
-
 ## [v1.2.3-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre7) (2024-06-14)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre6...v1.2.3-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4...v1.2.3-pre7)
+
+## [v1.2.4](https://github.com/microsoft/CoseSignTool/tree/v1.2.4) (2024-06-14)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre6...v1.2.4)
 
 **Merged pull requests:**
 
@@ -144,7 +156,7 @@
 
 ## [v1.2.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre2) (2024-03-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre2)
 
 **Closed issues:**
 
@@ -154,13 +166,13 @@
 
 - more granular error codes [\#86](https://github.com/microsoft/CoseSignTool/pull/86) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
-
 ## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.2)
+
+## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
 
 **Merged pull requests:**
 
@@ -180,15 +192,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
-
-## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
 
 ## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+
+## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.1.8-pre1)
 
 **Merged pull requests:**
 
@@ -216,19 +228,19 @@
 
 ## [v1.1.7-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.7-pre1) (2024-02-14)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6-pre1...v1.1.7-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7...v1.1.7-pre1)
 
 **Merged pull requests:**
 
 - Command Line Validation of Indirect Signatures [\#78](https://github.com/microsoft/CoseSignTool/pull/78) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.6-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.6-pre1) (2024-02-07)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7...v1.1.6-pre1)
-
 ## [v1.1.7](https://github.com/microsoft/CoseSignTool/tree/v1.1.7) (2024-02-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6...v1.1.7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6-pre1...v1.1.7)
+
+## [v1.1.6-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.6-pre1) (2024-02-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6...v1.1.6-pre1)
 
 **Merged pull requests:**
 
@@ -292,19 +304,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
-
 ## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
+
+## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
 
 **Closed issues:**
 

--- a/CoseHandler/Extensions/FileInfoExtensions.cs
+++ b/CoseHandler/Extensions/FileInfoExtensions.cs
@@ -27,7 +27,7 @@ public static class FileInfoExtensions
         DateTime startTime = DateTime.Now;
         int counter = 0;
         writeTo ??= OutputTarget.StdOut;
-        while (SecondsSince(startTime) < 30)
+        while (SecondsSince(startTime) < maxWaitTime)
         {
             try
             {

--- a/CoseSign1/CoseSign1MessageFactory.cs
+++ b/CoseSign1/CoseSign1MessageFactory.cs
@@ -132,7 +132,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
     // Checks to see if the payload is empty
     private static void ThrowIfEmpty(Stream stream)
     {
-        if (stream.IsNullOrEmpty())
+        if (stream.IsNullOrEmpty(10000))
         {
             throw new ArgumentOutOfRangeException(null, "The payload to sign is empty.");
         }

--- a/CoseSign1/Extensions/StreamExtensions.cs
+++ b/CoseSign1/Extensions/StreamExtensions.cs
@@ -12,28 +12,29 @@ public static class StreamExtensions
     /// Checks if the current <see cref="Stream"/> is null or empty.
     /// </summary>
     /// <param name="stream">The stream to check.</param>
+    /// <param name="maxWait">The number of milliseconds before timeout. Default is 100.</param>
     /// <returns>True if the stream is null or empty; false otherwise.</returns>
-    public static bool IsNullOrEmpty(this Stream? stream)
+    public static bool IsNullOrEmpty(this Stream? stream, int maxWait = 100)
     {
         if (stream == null)
         {
             return true;
         }
-
-        Task<bool> result = Task.Run(() => HasContent(stream));
+        DateTime dt = DateTime.Now;
+        Task<bool> result = Task.Run(() => HasContent(stream, maxWait));
 
         return !result.Result;
     }
 
 
-    private static async Task<bool> HasContent(Stream stream)
+    private static async Task<bool> HasContent(Stream stream, int maxWait = 100)
     {
         if (stream.CanSeek)
         {
             byte[] buffer = new byte[8];
 
             // If the stream is STDIN, it will otherwise wait indefinitely for input, so we need a timeout task.
-            Task timeout = Task.Delay(TimeSpan.FromMilliseconds(100));
+            Task timeout = Task.Delay(TimeSpan.FromMilliseconds(maxWait));
             Task<int> readStdin = stream.ReadAsync(buffer, 0, 8);
 
             // Go for 100 ms or until we read 8 bytes or reach end of stream, whichever happen first.

--- a/CoseSign1/Extensions/StreamExtensions.cs
+++ b/CoseSign1/Extensions/StreamExtensions.cs
@@ -20,7 +20,7 @@ public static class StreamExtensions
         {
             return true;
         }
-        DateTime dt = DateTime.Now;
+
         Task<bool> result = Task.Run(() => HasContent(stream, maxWait));
 
         return !result.Result;

--- a/CoseSignTool/CoseCommand.cs
+++ b/CoseSignTool/CoseCommand.cs
@@ -136,7 +136,7 @@ public abstract partial class CoseCommand
             {
                 content = UseAdvancedStreamHandling ? file.GetStreamResilient(MaxWaitTime) : file.GetStreamBasic(MaxWaitTime);
                 return
-                    content.IsNullOrEmpty() ?
+                    content.IsNullOrEmpty(10000) ?
                         CoseSignTool.Fail(ExitCode.EmptySourceFile, null, $"The file specified in /{optionName} was empty: {file.FullName}")
                     : ExitCode.Success;
             }
@@ -160,7 +160,7 @@ public abstract partial class CoseCommand
         content = Console.OpenStandardInput();
         string inputName = optionName == nameof(PayloadFile) ? "payload" : "signature";
         return
-            content.IsNullOrEmpty() ? CoseSignTool.Fail(ExitCode.MissingRequiredOption, null,
+            content.IsNullOrEmpty(10000) ? CoseSignTool.Fail(ExitCode.MissingRequiredOption, null,
                 $"You must either specify a {inputName} file or pass the {inputName} content in as a Stream.")                    
             : ExitCode.Success;
     }


### PR DESCRIPTION
When reading large payload files, the check in Stream.IsNullOrEmpty sometimes times out causing an empty payload error before it can complete the read operation. This change increases the timeout for those checks that would result in a Fail result from 100ms to 10 seconds.