### PR TITLE
Add kid header to protected headers

### DIFF
--- a/CoseSign1.Certificates.Tests/CertificateCoseSigningKeyProviderTests.cs
+++ b/CoseSign1.Certificates.Tests/CertificateCoseSigningKeyProviderTests.cs
@@ -129,7 +129,7 @@ public class CertificateCoseSigningKeyProviderTests
         testObj.Protected().Verify("GetSigningCertificate", Times.AtLeastOnce());
         testObj.Protected().Verify("GetCertificateChain", Times.Once(), X509ChainSortOrder.LeafFirst);
         response.Should().NotBeNull();
-        response.Count.Should().Be(2);
+        response.Count.Should().Be(3);
     }
 
     /// <summary>

--- a/CoseSign1.Tests/CoseSign1IntegrationTestsWithBuilder.cs
+++ b/CoseSign1.Tests/CoseSign1IntegrationTestsWithBuilder.cs
@@ -38,10 +38,10 @@ public class CoseSign1IntegrationTestsWithBuilder
         response.Should().BeOfType<CoseSign1Message>();
         response.ProtectedHeaders.Should().NotBeNull();
 
-        // There should be 4 ProtectedHeaders.
-        // First one is the algo header provided by Cosesigner. The second and third are from the Default ProtectedHeaders provided by CertificateCoseSignerKeyProvider
+        // There should be 5 ProtectedHeaders.
+        // First one is the algo header provided by Cosesigner. The second, third and fourth are from the Default ProtectedHeaders provided by CertificateCoseSignerKeyProvider
         // The last is the Content Type header provided by the user.
-        response.ProtectedHeaders.Should().HaveCount(c => c == 4);
+        response.ProtectedHeaders.Should().HaveCount(c => c == 5);
 
         response.UnprotectedHeaders.Should().BeEmpty();
     }
@@ -79,8 +79,8 @@ public class CoseSign1IntegrationTestsWithBuilder
         response.Should().BeOfType<CoseSign1Message>();
         response.ProtectedHeaders.Should().NotBeNull();
 
-        // The count of protected headers should be 5.
-        response.ProtectedHeaders.Should().HaveCount(c => c == 5);
+        // The count of protected headers should be 6.
+        response.ProtectedHeaders.Should().HaveCount(c => c == 6);
         response.ProtectedHeaders.First().Key.Should().Be(CoseHeaderLabel.Algorithm); // this is the algo header added by the CoseSigner
 
         // Count of Unprotected headers should be 1.

--- a/CoseSign1.Tests/CoseSign1IntegrationTestsWithFactory.cs
+++ b/CoseSign1.Tests/CoseSign1IntegrationTestsWithFactory.cs
@@ -40,7 +40,7 @@ public class CoseSign1IntegrationTestsWithFactory
         var responseAsCoseSign1Message = Factory.CreateCoseSign1Message(testPayload, testSigningKeyProvider);
         responseAsCoseSign1Message.Equals(CoseMessage.DecodeSign1(responseAsBytes.ToArray()));
 
-        responseAsCoseSign1Message.ProtectedHeaders.Should().HaveCount(c => c == 4);
+        responseAsCoseSign1Message.ProtectedHeaders.Should().HaveCount(c => c == 5);
 
         responseAsCoseSign1Message.UnprotectedHeaders.Should().BeEmpty();
     }
@@ -79,8 +79,8 @@ public class CoseSign1IntegrationTestsWithFactory
 
         responseAsCoseSign1Message.ProtectedHeaders.Should().NotBeNull();
 
-        //checking if the count of protected headers are 4.
-        responseAsCoseSign1Message.ProtectedHeaders.Should().HaveCount(c => c == 5);
+        //checking if the count of protected headers are 6.
+        responseAsCoseSign1Message.ProtectedHeaders.Should().HaveCount(c => c == 6);
 
         responseAsCoseSign1Message.ProtectedHeaders.First().Key.Should().Be(CoseHeaderLabel.Algorithm); // this is the algo header added by the CoseSigner
 


### PR DESCRIPTION
This PR contains code and test changes to add key identifier (KID) header to the protected headers. KID is a common COSE header parameter that identifies the cryptographic key used for signing. 