### PR TITLE
Remove Weak Algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.3.0-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre2) (2024-11-20)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre1...v1.3.0-pre2)
+
+**Merged pull requests:**
+
+- set shell in publish step [\#121](https://github.com/microsoft/CoseSignTool/pull/121) ([lemccomb](https://github.com/lemccomb))
+
 ## [v1.3.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre1) (2024-11-20)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.0.0-Test1...v1.3.0-pre1)
@@ -14,7 +22,7 @@
 
 ## [v1.2.8-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre7) (2024-10-30)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre6...v1.2.8-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0...v1.2.8-pre7)
 
 **Closed issues:**
 
@@ -24,13 +32,13 @@
 
 - Adds CLI install instructions [\#116](https://github.com/microsoft/CoseSignTool/pull/116) ([ivarprudnikov](https://github.com/ivarprudnikov))
 
-## [v1.2.8-pre6](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre6) (2024-10-30)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0...v1.2.8-pre6)
-
 ## [v1.3.0](https://github.com/microsoft/CoseSignTool/tree/v1.3.0) (2024-10-30)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre5...v1.3.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre6...v1.3.0)
+
+## [v1.2.8-pre6](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre6) (2024-10-30)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre5...v1.2.8-pre6)
 
 **Merged pull requests:**
 
@@ -216,7 +224,7 @@
 
 ## [v1.2.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre2) (2024-03-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.1-pre2)
 
 **Closed issues:**
 
@@ -226,13 +234,13 @@
 
 - more granular error codes [\#86](https://github.com/microsoft/CoseSignTool/pull/86) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.2)
-
 ## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
+
+## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.2)
 
 **Merged pull requests:**
 
@@ -252,15 +260,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
-
-## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
 
 ## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+
+## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8...v1.1.8-pre1)
 
 **Merged pull requests:**
 
@@ -449,7 +457,7 @@
 
 ## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v1.1.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v1.1.0)
 
 **Merged pull requests:**
 
@@ -459,13 +467,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
-
 ## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
+
+## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
 
 **Merged pull requests:**
 

--- a/CoseHandler.Tests/CoseX509ThumbprintTests.cs
+++ b/CoseHandler.Tests/CoseX509ThumbprintTests.cs
@@ -28,7 +28,7 @@ public class CoseX509ThumbprintTests
     {
         var algos = new HashAlgorithm[]
         {
-            SHA1.Create(), SHA256.Create(), SHA384.Create(), SHA512.Create()
+            SHA256.Create(), SHA384.Create(), SHA512.Create()
         };
 
         foreach (HashAlgorithm algo in algos)

--- a/CoseHandler.Tests/CoseX509ThumbprintTests.cs
+++ b/CoseHandler.Tests/CoseX509ThumbprintTests.cs
@@ -48,6 +48,6 @@ public class CoseX509ThumbprintTests
     [ExpectedException(typeof(CoseX509FormatException))]
     public void ConstructThumbprintWithUnsupportedAlgo()
     {
-        _ = new CoseX509Thumprint(SelfSignedCert1, HashAlgorithmName.MD5);
+        _ = new CoseX509Thumprint(SelfSignedCert1, HashAlgorithmName.SHA3_512);
     }
 }

--- a/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
+++ b/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
@@ -201,20 +201,20 @@ public class IndirectSignatureFactoryTests
     }
 
     [Test]
-    public void TestCreateIndirectSignatureMd5Failure()
+    public void TestCreateIndirectSignatureUnsupportedAlgorithmFailure()
     {
-        Action act = () => { IndirectSignatureFactory factory = new(HashAlgorithmName.MD5); };
+        Action act = () => { IndirectSignatureFactory factory = new(HashAlgorithmName.SHA3_384); };
         act.Should().Throw<ArgumentException>();
     }
 
     [Test]
-    public void TestCreateIndirectSignatureMd5HashProvidedFailure()
+    public void TestCreateIndirectSignatureUnsupportedAlgorithmNameFailure()
     {
         ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
         using IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
-        using HashAlgorithm hasher = CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName(HashAlgorithmName.MD5)
+        using HashAlgorithm hasher = CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName(HashAlgorithmName.SHA3_384)
          ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName)}");
         byte[] hash = hasher!.ComputeHash(randomBytes);
 

--- a/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
+++ b/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
@@ -203,24 +203,8 @@ public class IndirectSignatureFactoryTests
     [Test]
     public void TestCreateIndirectSignatureUnsupportedAlgorithmFailure()
     {
-        Action act = () => { IndirectSignatureFactory factory = new(HashAlgorithmName.SHA3_384); };
+        Action act = () => { IndirectSignatureFactory factory = new(HashAlgorithmName.SHA3_256); };
         act.Should().Throw<ArgumentException>();
-    }
-
-    [Test]
-    public void TestCreateIndirectSignatureUnsupportedAlgorithmNameFailure()
-    {
-        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
-        using IndirectSignatureFactory factory = new();
-        byte[] randomBytes = new byte[50];
-        new Random().NextBytes(randomBytes);
-        using HashAlgorithm hasher = CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName(HashAlgorithmName.SHA3_384)
-         ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName)}");
-        byte[] hash = hasher!.ComputeHash(randomBytes);
-
-        // test the sync method
-        Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, string.Empty));
-        Assert.Throws<ArgumentException>(() => factory.CreateIndirectSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload"));
     }
 
     [Test]

--- a/CoseIndirectSignature/IndirectSignatureFactory.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.cs
@@ -601,8 +601,6 @@ public sealed class IndirectSignatureFactory : IDisposable
     private static readonly ConcurrentDictionary<int, HashAlgorithmName> SizeInBytesToAlgorithm = new(
         new Dictionary<int, HashAlgorithmName>()
         {
-            { 16, HashAlgorithmName.MD5 },
-            { 20, HashAlgorithmName.SHA1 },
             { 32, HashAlgorithmName.SHA256 },
             { 48, HashAlgorithmName.SHA384 },
             { 64, HashAlgorithmName.SHA512 }

--- a/CoseSign1.Certificates.Tests/X509Certificate2SigningKeyProviderTests.cs
+++ b/CoseSign1.Certificates.Tests/X509Certificate2SigningKeyProviderTests.cs
@@ -30,7 +30,6 @@ public class X509Certificate2SigningKeyProviderTests
             new Action(() => _= new X509Certificate2CoseSigningKeyProvider(testCert)),
             new Action(() => _= new X509Certificate2CoseSigningKeyProvider(testCert, HashAlgorithmName.SHA256)),
             new Action(() => _= new X509Certificate2CoseSigningKeyProvider(testCert, HashAlgorithmName.SHA512)),
-            new Action(() => _= new X509Certificate2CoseSigningKeyProvider(testCert, HashAlgorithmName.SHA1)),
         ];
 
         // test validate

--- a/CoseSign1.Certificates/CoseX509Thumbprint.cs
+++ b/CoseSign1.Certificates/CoseX509Thumbprint.cs
@@ -18,7 +18,6 @@ public class CoseX509Thumprint
     /// </summary>
     private static readonly Dictionary<int, HashAlgorithmName> HashAlgorithmToCoseValues = new()
     {
-        { -14, HashAlgorithmName.SHA1 },
         { -16, HashAlgorithmName.SHA256 },
         { -43, HashAlgorithmName.SHA384 },
         { -44, HashAlgorithmName.SHA512 }
@@ -162,7 +161,6 @@ public class CoseX509Thumprint
 
         // HashAlgorithmName values are not constants, so we can't use an actual switch here.
         Hasher =
-            algName == HashAlgorithmName.SHA1 ? SHA1.Create() :
             algName == HashAlgorithmName.SHA256 ? SHA256.Create() :
             algName == HashAlgorithmName.SHA384 ? SHA384.Create() :
             algName == HashAlgorithmName.SHA512 ? SHA512.Create() :


### PR DESCRIPTION
In order to maintain compliance with CodeQL guidelines, all references to weak cryptographic algorithms have been removed from the codebase (`HashAlgorithmName.MD5` and `HashAlgorithmName.SHA1`). 

`HashAlgorithmName.MD5`: All references were from test code, so no behavior was changed for this algorithm (remains unsupported). 

`HashAlgorithmName.SHA1`: Is no longer supported for the creation of new Indirect Signatures, or as a hash algorithm for key providers. To prevent potential security vulnerabilities, consumers should remove any dependencies on this algorithm when using these libraries.