### PR TITLE
Migrate from VSTest to MTP

### DIFF
--- a/CoseHandler.Tests/CoseHandler.Tests.csproj
+++ b/CoseHandler.Tests/CoseHandler.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -22,10 +23,9 @@
 	<!-- Package references -->
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 	</ItemGroup>
 
 	<!-- Project refrences-->

--- a/CoseIndirectSignature.Tests/CoseIndirectSignature.Tests.csproj
+++ b/CoseIndirectSignature.Tests/CoseIndirectSignature.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
@@ -21,12 +22,11 @@
 
 	<!-- Package references -->
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.3.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
+++ b/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -19,10 +20,9 @@
 	<!-- Package references -->
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.3.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CoseSign1.Headers.Tests/CoseSign1.Headers.Tests.csproj
+++ b/CoseSign1.Headers.Tests/CoseSign1.Headers.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -18,10 +19,9 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
         <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/CoseSign1.Tests/CoseSign1.Tests.csproj
+++ b/CoseSign1.Tests/CoseSign1.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -18,12 +19,11 @@
 
 	<!-- Package references -->
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.3.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CoseSignTool.Tests/CoseSignTool.Tests.csproj
+++ b/CoseSignTool.Tests/CoseSignTool.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>AnyCPU</Platforms>
 		<!-- must match the platform set from CoseSignTool	-->
@@ -26,9 +27,8 @@
 	<!-- Package references -->
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
 	</ItemGroup>
 
 	<!-- Project references -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+﻿<Project>
+  <PropertyGroup>
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This migrates from VSTest, to the newer Microsoft.Testing.Platform