### PR TITLE
Add support for CoseHashEnvelope

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: 'csharp'
         queries: security-extended,security-and-quality 
@@ -50,6 +50,6 @@ jobs:
 
     # Do the analysis
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
+++ b/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
@@ -1,0 +1,391 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Ignore Spelling: Cose Deserialization
+
+namespace CoseIndirectSignature.Tests;
+
+using System.Net.Mime;
+using Microsoft.VisualStudio.TestTools.UnitTesting;     // Do not make global because it will conflict with NUnit.
+
+public class CoseHashEnvelopeTests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void TestFactoryDefaultCreatesCoseHashEnvelop()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        using IndirectSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        using HashAlgorithm hasher = CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName(factory.HashAlgorithmName)
+                 ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName)}");
+        byte[] hash = hasher!.ComputeHash(randomBytes);
+
+        CoseSign1Message coseSign1Message = factory.CreateIndirectSignature(
+            randomBytes,
+            coseSigningKeyProvider,
+            "application/test.payload");
+
+        // should be CoseHashEnvelope
+        coseSign1Message.TryGetIsCoseHashEnvelope().Should().BeTrue();
+        // should not be CoseHashV
+        coseSign1Message.TryGetIsCoseHashVContentType().Should().BeFalse();
+        // should not be IndirectSignature type.
+        coseSign1Message.TryGetIndirectSignatureAlgorithm(out _).Should().BeFalse();
+
+        // check attributes
+        coseSign1Message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+
+        coseSign1Message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test.payload");
+
+        coseSign1Message.TryGetPayloadLocation(out string? payloadLocation).Should().BeFalse();
+        payloadLocation.Should().BeNull();
+
+        // hashes should match
+        coseSign1Message.Content.Value.ToArray().Should().BeEquivalentTo(hash);
+
+        // signatures should match
+        coseSign1Message.SignatureMatches(randomBytes).Should().BeTrue();
+    }
+
+    [Test]
+    public void TestFactoryExplicitCreatesCoseHashEnvelop()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        using IndirectSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        using HashAlgorithm hasher = CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName(factory.HashAlgorithmName)
+                 ?? throw new Exception($"Failed to get hash algorithm from {nameof(CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName)}");
+        byte[] hash = hasher!.ComputeHash(randomBytes);
+
+        CoseSign1Message coseSign1Message = factory.CreateIndirectSignature(
+            randomBytes, coseSigningKeyProvider,
+            "application/test.payload",
+            IndirectSignatureFactory.IndirectSignatureVersion.CoseHashEnvelope);
+        // should be CoseHashEnvelope
+        coseSign1Message.TryGetIsCoseHashEnvelope().Should().BeTrue();
+        // should not be CoseHashV
+        coseSign1Message.TryGetIsCoseHashVContentType().Should().BeFalse();
+        // should not be IndirectSignature type.
+        coseSign1Message.TryGetIndirectSignatureAlgorithm(out _).Should().BeFalse();
+
+        // check attributes
+        coseSign1Message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+
+        coseSign1Message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test.payload");
+
+        coseSign1Message.TryGetPayloadLocation(out string? payloadLocation).Should().BeFalse();
+        payloadLocation.Should().BeNull();
+
+        // hashes should match
+        coseSign1Message.Content.Value.ToArray().Should().BeEquivalentTo(hash);
+
+        // signatures should match
+        coseSign1Message.SignatureMatches(randomBytes).Should().BeTrue();
+    }
+
+    [Test]
+    [TestCase(1, Description = "TryGetIsCoseHashEnvelope")]
+    [TestCase(2, Description = "TryGetPayloadHashAlgorithm")]
+    [TestCase(3, Description = "TryGetPreImageContentType")]
+    [TestCase(4, Description = "TryGetPayloadLocation")]
+    public void TestExtensionMethodNullHandling(int testCase)
+    {
+        CoseSign1Message? coseSign1Message = null;
+        switch (testCase)
+        {
+            case 1:
+                coseSign1Message.TryGetIsCoseHashEnvelope().Should().BeFalse();
+                break;
+            case 2:
+                coseSign1Message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeFalse();
+                algoName.Should().BeNull();
+                break;
+            case 3:
+                coseSign1Message.TryGetPreImageContentType(out string? contentType).Should().BeFalse();
+                contentType.Should().BeNull();
+                break;
+            case 4:
+                coseSign1Message.TryGetPayloadLocation(out string? payloadLocation).Should().BeFalse();
+                payloadLocation.Should().BeNull();
+                break;
+        }
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopeMinusContentShouldInvalidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: false,
+                            headerExtender: new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test"));
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeFalse();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+        message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test");
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopePayloadHashAlgorithmUnprotectedHeaderShouldInvalidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+        CoseHeaderMap protectedHeader = new();
+        CoseHeaderMap unProtectedHeader = new();
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test");
+        protectedHeader = headerExtender.ExtendProtectedHeaders(protectedHeader);
+        protectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg]);
+        unProtectedHeader = headerExtender.ExtendProtectedHeaders(unProtectedHeader);
+        unProtectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PreimageContentType]);
+        unProtectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadLocation]);
+
+        mockHeaderExtender.Setup(x => x.ExtendProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(protectedHeader);
+        mockHeaderExtender.Setup(x => x.ExtendUnProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(unProtectedHeader);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: mockHeaderExtender.Object);
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeFalse();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeFalse();
+        algoName.Should().BeNull();
+        message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test");
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopeInvalidPayloadHashAlgorithmShouldInvalidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+        CoseHeaderMap protectedHeader = new();
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test");
+        protectedHeader = headerExtender.ExtendProtectedHeaders(protectedHeader);
+        protectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg]);
+        // add a bogus payload hash algo
+        protectedHeader.Add(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], CoseHeaderValue.FromInt32(9953));
+
+        mockHeaderExtender.Setup(x => x.ExtendProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(protectedHeader);
+        mockHeaderExtender.Setup(x => x.ExtendUnProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns([]);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: mockHeaderExtender.Object);
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeFalse();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeFalse();
+        algoName.Should().BeNull();
+        message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test");
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopePayloadPreImageContentTypeUnprotectedHeaderShouldValidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+        CoseHeaderMap protectedHeader = new();
+        CoseHeaderMap unProtectedHeader = new();
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test");
+        protectedHeader = headerExtender.ExtendProtectedHeaders(protectedHeader);
+        protectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PreimageContentType]);
+        unProtectedHeader = headerExtender.ExtendProtectedHeaders(unProtectedHeader);
+        unProtectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg]);
+        unProtectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadLocation]);
+
+        mockHeaderExtender.Setup(x => x.ExtendProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(protectedHeader);
+        mockHeaderExtender.Setup(x => x.ExtendUnProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(unProtectedHeader);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: mockHeaderExtender.Object);
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeTrue();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+        message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test");
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopePayloadNoPreImageContentShouldValidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+        CoseHeaderMap protectedHeader = new();
+        CoseHeaderMap unProtectedHeader = new();
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test");
+        protectedHeader = headerExtender.ExtendProtectedHeaders(protectedHeader);
+        protectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PreimageContentType]);
+
+        mockHeaderExtender.Setup(x => x.ExtendProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(protectedHeader);
+        mockHeaderExtender.Setup(x => x.ExtendUnProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(unProtectedHeader);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: mockHeaderExtender.Object);
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeTrue();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+        message.TryGetPreImageContentType(out string? contentType).Should().BeFalse();
+        contentType.Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopePayloadLocationProtectedHeaderShouldValidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test", "payload_location");
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: headerExtender);
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeTrue();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+        message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test");
+        message.TryGetPayloadLocation(out string? payloadLocation).Should().BeTrue();
+        payloadLocation.Should().Be("payload_location");
+    }
+
+    [Test]
+    public void ValidCoseHashEnvelopePayloadLocationUnProtectedHeaderShouldInvalidate()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+        CoseHeaderMap protectedHeader = new();
+        CoseHeaderMap unProtectedHeader = new();
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test", "payload_location");
+        protectedHeader = headerExtender.ExtendProtectedHeaders(protectedHeader);
+        protectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadLocation]);
+        unProtectedHeader = headerExtender.ExtendProtectedHeaders(unProtectedHeader);
+        unProtectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg]);
+        unProtectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PreimageContentType]);
+
+        mockHeaderExtender.Setup(x => x.ExtendProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(protectedHeader);
+        mockHeaderExtender.Setup(x => x.ExtendUnProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(unProtectedHeader);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: mockHeaderExtender.Object);
+        message.Should().NotBeNull();
+        message!.TryGetIsCoseHashEnvelope().Should().BeTrue();
+        message.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algoName).Should().BeTrue();
+        algoName.Should().Be(CoseHashAlgorithm.SHA256);
+        message.TryGetPreImageContentType(out string? contentType).Should().BeTrue();
+        contentType.Should().Be("application/test");
+        message.TryGetPayloadLocation(out string? payloadLocation).Should().BeFalse();
+        payloadLocation.Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public void CoseMessage1MinusContentShouldNotHashMatch()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: false,
+                            headerExtender: new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test"));
+        message.Should().NotBeNull();
+        Assert.ThrowsException<InvalidCoseDataException>(() => message.SignatureMatchesInternalCoseHashEnvelope(randomBytes));
+    }
+
+    [Test]
+    public void CoseMessage1BadAlgorithmShouldNotHashMatch()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
+        CoseHeaderMap protectedHeader = new();
+
+        CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test");
+        protectedHeader = headerExtender.ExtendProtectedHeaders(protectedHeader);
+        protectedHeader.Remove(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg]);
+        // add a bogus payload hash algo
+        protectedHeader.Add(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], CoseHeaderValue.FromInt32(9953));
+
+        mockHeaderExtender.Setup(x => x.ExtendProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns(protectedHeader);
+        mockHeaderExtender.Setup(x => x.ExtendUnProtectedHeaders(It.IsAny<CoseHeaderMap>())).Returns([]);
+
+        CoseSign1Message? message = factory.CreateCoseSign1Message(
+                            randomBytes,
+                            coseSigningKeyProvider,
+                            embedPayload: true,
+                            headerExtender: mockHeaderExtender.Object);
+        message.Should().NotBeNull();
+        Assert.ThrowsException<InvalidCoseDataException>(() => message.SignatureMatchesInternalCoseHashEnvelope(randomBytes));
+    }
+}

--- a/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
+++ b/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
@@ -287,7 +287,6 @@ public class CoseHashEnvelopeTests
 
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
-        Mock<ICoseHeaderExtender> mockHeaderExtender = new(MockBehavior.Strict);
 
         CoseHashEnvelopeHeaderExtender headerExtender = new CoseHashEnvelopeHeaderExtender(HashAlgorithmName.SHA256, "application/test", "payload_location");
         CoseSign1Message? message = factory.CreateCoseSign1Message(

--- a/CoseIndirectSignature.Tests/CoseSign1MessageIndirectSignatureExtensionsTests.cs
+++ b/CoseIndirectSignature.Tests/CoseSign1MessageIndirectSignatureExtensionsTests.cs
@@ -24,8 +24,9 @@ public class CoseSign1MessageIndirectSignatureExtensionsTests
         IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
-
-        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", useOldFormat: true);
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.Direct);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.TryGetIndirectSignatureAlgorithm(out HashAlgorithmName hashAlgorithmName).Should().BeTrue();
         hashAlgorithmName.Should().Be(HashAlgorithmName.SHA256);
     }
@@ -94,8 +95,9 @@ public class CoseSign1MessageIndirectSignatureExtensionsTests
         IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
-
-        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.Direct);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.IsIndirectSignature().Should().BeTrue();
     }
 
@@ -194,7 +196,9 @@ public class CoseSign1MessageIndirectSignatureExtensionsTests
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
 
-        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", useOldFormat: true);
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.Direct);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.TryGetHashAlgorithm(out HashAlgorithm? hashAlgorithm).Should().BeTrue();
         hashAlgorithm.Should().NotBeNull();
         hashAlgorithm.Should().BeAssignableTo<SHA256>();
@@ -221,7 +225,7 @@ public class CoseSign1MessageIndirectSignatureExtensionsTests
         {
             // test the fetching case
             case 1:
-                CoseSign1Message? testObj1 = signaturefactory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+                CoseSign1Message? testObj1 = signaturefactory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", useOldFormat: true);
                 CoseHashV hashObject = testObj1.GetCoseHashV();
                 hashObject.ContentMatches(randomBytes).Should().BeTrue();
                 break;
@@ -245,7 +249,7 @@ public class CoseSign1MessageIndirectSignatureExtensionsTests
                 break;
             // tryget success
             case 5:
-                CoseSign1Message? testObj5 = signaturefactory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+                CoseSign1Message? testObj5 = signaturefactory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", useOldFormat: true);
                 testObj5.TryGetCoseHashV(out CoseHashV? hashObject5).Should().BeTrue();
                 hashObject5.ContentMatches(randomBytes).Should().BeTrue();
                 break;

--- a/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
+++ b/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
@@ -45,14 +45,30 @@ public class IndirectSignatureFactoryTests
 
         // test the sync method
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureCurrent = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrent.TryGetPreImageContentType(out string? payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrent.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature.SignatureMatches(randomBytes).Should().BeTrue();
+        memStream.Seek(0, SeekOrigin.Begin);
+
 
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignature(memStream, coseSigningKeyProvider, string.Empty));
         memStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature2 = factory.CreateIndirectSignature(memStream, coseSigningKeyProvider, "application/test.payload");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature2 = factory.CreateIndirectSignature(memStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature2.SignatureMatches(randomBytes).Should().BeTrue();
@@ -60,14 +76,37 @@ public class IndirectSignatureFactoryTests
 
         // test the async methods
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureAsync(randomBytes, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature3 = await factory.CreateIndirectSignatureAsync(randomBytes, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureCurrentAsync = await factory.CreateIndirectSignatureAsync(randomBytes, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureCurrentAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrentAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrentAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrentAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature3 = await factory.CreateIndirectSignatureAsync(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature3.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureAsync(memStream, coseSigningKeyProvider, string.Empty));
         memStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature4 = await factory.CreateIndirectSignatureAsync(memStream, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureCurrentStreamAsync = await factory.CreateIndirectSignatureAsync(memStream, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureCurrentStreamAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrentStreamAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrentStreamAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrentStreamAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        memStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature4 = await factory.CreateIndirectSignatureAsync(memStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature4.SignatureMatches(randomBytes).Should().BeTrue();
@@ -88,14 +127,37 @@ public class IndirectSignatureFactoryTests
 
         // test the sync method
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature = factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureCurrent = factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrent.TryGetPreImageContentType(out string? payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrent.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature.SignatureMatches(randomBytes).Should().BeTrue();
 
-        Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignature(hashStream, coseSigningKeyProvider, string.Empty));
+        Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureFromHash(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature2 = factory.CreateIndirectSignatureFromHash(hashStream, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureStreamCurrent = factory.CreateIndirectSignatureFromHash(hashStream, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureStreamCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureStreamCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureStreamCurrent.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureStreamCurrent.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature2 = factory.CreateIndirectSignatureFromHash(hashStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature2.SignatureMatches(randomBytes).Should().BeTrue();
@@ -103,14 +165,38 @@ public class IndirectSignatureFactoryTests
 
         // test the async methods
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureFromHashAsync(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature3 = await factory.CreateIndirectSignatureFromHashAsync(hash, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureCurrentAsync = factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureCurrentAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrentAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrentAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrentAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature3 = await factory.CreateIndirectSignatureFromHashAsync(hash, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature3.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureFromHashAsync(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature4 = await factory.CreateIndirectSignatureFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload");
+
+        CoseSign1Message IndirectSignatureCurrentStreamAsync = factory.CreateIndirectSignatureFromHash(hash, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignatureCurrentStreamAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrentStreamAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrentStreamAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrentStreamAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature4 = await factory.CreateIndirectSignatureFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV);
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature4.SignatureMatches(randomBytes).Should().BeTrue();
@@ -128,14 +214,37 @@ public class IndirectSignatureFactoryTests
 
         // test the sync method
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureBytes(randomBytes, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(randomBytes, coseSigningKeyProvider, "application/test.payload").ToArray());
+
+        CoseSign1Message IndirectSignatureCurrent = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(randomBytes, coseSigningKeyProvider, "application/test.payload").ToArray());
+        IndirectSignatureCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrent.TryGetPreImageContentType(out string? payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrent.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureBytes(memStream, coseSigningKeyProvider, string.Empty));
         memStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature2 = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(memStream, coseSigningKeyProvider, "application/test.payload").ToArray());
+
+        CoseSign1Message IndirectSignatureStreamCurrent = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(memStream, coseSigningKeyProvider, "application/test.payload").ToArray());
+        IndirectSignatureStreamCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureStreamCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureStreamCurrent.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureStreamCurrent.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        memStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature2 = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(memStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature2.SignatureMatches(randomBytes).Should().BeTrue();
@@ -143,14 +252,37 @@ public class IndirectSignatureFactoryTests
 
         // test the async methods
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureBytesAsync(randomBytes, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature3 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesAsync(randomBytes, coseSigningKeyProvider, "application/test.payload")).ToArray());
+
+        CoseSign1Message IndirectSignatureCurrentAsync = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(randomBytes, coseSigningKeyProvider, "application/test.payload").ToArray());
+        IndirectSignatureCurrentAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrentAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrentAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrentAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature3 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesAsync(randomBytes, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV)).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature3.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureBytesAsync(memStream, coseSigningKeyProvider, string.Empty));
         memStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature4 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesAsync(memStream, coseSigningKeyProvider, "application/test.payload")).ToArray());
+
+        CoseSign1Message IndirectSignatureCurrentStreamAsync = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesAsync(memStream, coseSigningKeyProvider, "application/test.payload")).ToArray());
+        IndirectSignatureCurrentStreamAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrentStreamAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrentStreamAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrentStreamAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        memStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature4 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesAsync(memStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV)).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         memStream.Seek(0, SeekOrigin.Begin);
@@ -171,14 +303,37 @@ public class IndirectSignatureFactoryTests
 
         // test the sync method
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureBytesFromHash(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload").ToArray());
+
+        CoseSign1Message IndirectSignatureCurrent = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload").ToArray());
+        IndirectSignatureCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureCurrent.TryGetPreImageContentType(out string? payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureCurrent.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignatureBytesFromHash(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature2 = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hashStream, coseSigningKeyProvider, "application/test.payload").ToArray());
+
+        CoseSign1Message IndirectSignatureStreamCurrent = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hashStream, coseSigningKeyProvider, "application/test.payload").ToArray());
+        IndirectSignatureStreamCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureStreamCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureStreamCurrent.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureStreamCurrent.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature2 = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hashStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature2.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature2.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature2.SignatureMatches(randomBytes).Should().BeTrue();
@@ -186,14 +341,37 @@ public class IndirectSignatureFactoryTests
 
         // test the async methods
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureBytesFromHashAsync(hash, coseSigningKeyProvider, string.Empty));
-        CoseSign1Message IndirectSignature3 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesFromHashAsync(hash, coseSigningKeyProvider, "application/test.payload")).ToArray());
+
+        CoseSign1Message IndirectSignatureHashCurrent = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytesFromHash(hash, coseSigningKeyProvider, "application/test.payload").ToArray());
+        IndirectSignatureHashCurrent.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureHashCurrent.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureHashCurrent.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureHashCurrent.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature3 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesFromHashAsync(hash, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV)).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature3.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature3.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         IndirectSignature3.SignatureMatches(randomBytes).Should().BeTrue();
 
         Assert.ThrowsAsync<ArgumentNullException>(() => factory.CreateIndirectSignatureBytesFromHashAsync(hashStream, coseSigningKeyProvider, string.Empty));
         hashStream.Seek(0, SeekOrigin.Begin);
-        CoseSign1Message IndirectSignature4 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload")).ToArray());
+
+        CoseSign1Message IndirectSignatureHashCurrentAsync = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload")).ToArray());
+        IndirectSignatureHashCurrentAsync.IsIndirectSignature().Should().BeTrue();
+        IndirectSignatureHashCurrentAsync.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignatureHashCurrentAsync.TryGetPreImageContentType(out payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignatureHashCurrentAsync.TryGetPayloadHashAlgorithm(out algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
+        hashStream.Seek(0, SeekOrigin.Begin);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        CoseSign1Message IndirectSignature4 = CoseMessage.DecodeSign1((await factory.CreateIndirectSignatureBytesFromHashAsync(hashStream, coseSigningKeyProvider, "application/test.payload", IndirectSignatureFactory.IndirectSignatureVersion.CoseHashV)).ToArray());
+#pragma warning restore CS0618 // Type or member is obsolete
         IndirectSignature4.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
         IndirectSignature4.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
         hashStream.Seek(0, SeekOrigin.Begin);
@@ -221,9 +399,12 @@ public class IndirectSignatureFactoryTests
         // test the sync method
         Assert.Throws<ArgumentNullException>(() => factory.CreateIndirectSignature(hash, coseSigningKeyProvider, string.Empty));
         CoseSign1Message IndirectSignature = CoseMessage.DecodeSign1(factory.CreateIndirectSignatureBytes(randomBytes, coseSigningKeyProvider, "application/test.payload").ToArray());
-        IndirectSignature.ProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType).Should().BeTrue();
-        IndirectSignature.ProtectedHeaders[CoseHeaderLabel.ContentType].GetValueAsString().Should().Be("application/test.payload+cose-hash-v");
+        IndirectSignature.IsIndirectSignature().Should().BeTrue();
         IndirectSignature.SignatureMatches(randomBytes).Should().BeTrue();
+        IndirectSignature.TryGetPreImageContentType(out string? payloadType).Should().Be(true);
+        payloadType!.Should().Be("application/test.payload");
+        IndirectSignature.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algo).Should().BeTrue();
+        algo!.Should().Be(CoseHashAlgorithm.SHA256);
     }
 
     private static ICoseSigningKeyProvider SetupMockSigningKeyProvider([CallerMemberName] string testName = "none")

--- a/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
+++ b/CoseIndirectSignature.Tests/IndirectSignatureFactoryTests.cs
@@ -37,7 +37,7 @@ public class IndirectSignatureFactoryTests
     [Test]
     public async Task TestCreateIndirectSignatureAsync()
     {
-        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
         using IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
@@ -116,7 +116,7 @@ public class IndirectSignatureFactoryTests
     [Test]
     public async Task TestCreateIndirectSignatureHashProvidedAsync()
     {
-        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
         using IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
@@ -206,7 +206,7 @@ public class IndirectSignatureFactoryTests
     [Test]
     public async Task TestCreateIndirectSignatureBytesAsync()
     {
-        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
         using IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
@@ -292,7 +292,7 @@ public class IndirectSignatureFactoryTests
     [Test]
     public async Task TestCreateIndirectSignatureBytesHashProvidedAsync()
     {
-        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
         using IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
@@ -388,7 +388,7 @@ public class IndirectSignatureFactoryTests
     [Test]
     public void TestCreateIndirectSignatureAlreadyProvided()
     {
-        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
         using IndirectSignatureFactory factory = new();
         byte[] randomBytes = new byte[50];
         new Random().NextBytes(randomBytes);
@@ -405,20 +405,5 @@ public class IndirectSignatureFactoryTests
         payloadType!.Should().Be("application/test.payload");
         IndirectSignature.TryGetPayloadHashAlgorithm(out CoseHashAlgorithm? algo).Should().BeTrue();
         algo!.Should().Be(CoseHashAlgorithm.SHA256);
-    }
-
-    private static ICoseSigningKeyProvider SetupMockSigningKeyProvider([CallerMemberName] string testName = "none")
-    {
-        Mock<ICoseSigningKeyProvider> mockedSignerKeyProvider = new(MockBehavior.Strict);
-        X509Certificate2 selfSignedCertWithRSA = TestCertificateUtils.CreateCertificate(testName);
-
-        mockedSignerKeyProvider.Setup(x => x.GetProtectedHeaders()).Returns<CoseHeaderMap>(null);
-        mockedSignerKeyProvider.Setup(x => x.GetUnProtectedHeaders()).Returns<CoseHeaderMap>(null);
-        mockedSignerKeyProvider.Setup(x => x.HashAlgorithm).Returns(HashAlgorithmName.SHA256);
-        mockedSignerKeyProvider.Setup(x => x.GetECDsaKey(It.IsAny<bool>())).Returns<ECDsa>(null);
-        mockedSignerKeyProvider.Setup(x => x.GetRSAKey(It.IsAny<bool>())).Returns(selfSignedCertWithRSA.GetRSAPrivateKey());
-        mockedSignerKeyProvider.Setup(x => x.IsRSA).Returns(true);
-
-        return mockedSignerKeyProvider.Object;
     }
 }

--- a/CoseIndirectSignature.Tests/TestUtils.cs
+++ b/CoseIndirectSignature.Tests/TestUtils.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature.Tests;
+
+/// <summary>
+/// Test utility methods.
+/// </summary>
+public static class TestUtils
+{
+    /// <summary>
+    /// Sets up a mock signing key provider for testing purposes.
+    /// </summary>
+    /// <param name="testName">The name of the test, defaults to the calling member.</param>
+    /// <returns>A <see cref="Mock{ICoseSigningKeyProvider}"/> which uses a self-signed certificate for signing operations.</returns>
+    public static ICoseSigningKeyProvider SetupMockSigningKeyProvider([CallerMemberName] string testName = "none")
+    {
+        Mock<ICoseSigningKeyProvider> mockedSignerKeyProvider = new(MockBehavior.Strict);
+        X509Certificate2 selfSignedCertWithRSA = TestCertificateUtils.CreateCertificate(testName);
+
+        mockedSignerKeyProvider.Setup(x => x.GetProtectedHeaders()).Returns<CoseHeaderMap>(null);
+        mockedSignerKeyProvider.Setup(x => x.GetUnProtectedHeaders()).Returns<CoseHeaderMap>(null);
+        mockedSignerKeyProvider.Setup(x => x.HashAlgorithm).Returns(HashAlgorithmName.SHA256);
+        mockedSignerKeyProvider.Setup(x => x.GetECDsaKey(It.IsAny<bool>())).Returns<ECDsa>(null);
+        mockedSignerKeyProvider.Setup(x => x.GetRSAKey(It.IsAny<bool>())).Returns(selfSignedCertWithRSA.GetRSAPrivateKey());
+        mockedSignerKeyProvider.Setup(x => x.IsRSA).Returns(true);
+
+        return mockedSignerKeyProvider.Object;
+    }
+}

--- a/CoseIndirectSignature/CoseHashEnvelopeHeaderExtender.cs
+++ b/CoseIndirectSignature/CoseHashEnvelopeHeaderExtender.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature;
+
+using System.Collections.Generic;
+using System.Security.Cryptography.Cose;
+
+/// <summary>
+/// Enumeration of COSE Hash Envelope header labels.
+/// From https://www.iana.org/assignments/cose/cose.xhtml
+/// </summary>
+public enum CoseHashEnvelopeHeaderLabels : long
+{
+    /// <summary>
+    /// No header label is defined.
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// The hash algorithm used to produce the payload.
+    /// </summary>
+    PayloadHashAlg = 258,
+    /// <summary>
+    /// The content type of the bytes that were hashed (preimage) to produce the payload, given as a content-format number or as a media-type name optionally with parameters.
+    /// </summary>
+    PreimageContentType = 259,
+    /// <summary>
+    /// An identifier enabling retrieval of the original resource (preimage) identified by the payload.
+    /// </summary>
+    PayloadLocation = 260
+}
+
+/// <summary>
+/// This class implements the <see cref="ICoseHeaderExtender"/> interface for a CoseHashEnvelope indirect signature.
+/// </summary>
+public class CoseHashEnvelopeHeaderExtender: ICoseHeaderExtender
+{
+    private readonly HashAlgorithmName HashAlgoName;
+    private readonly string ContentType;
+    private readonly string? PayloadLocation;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CoseHashEnvelopeHeaderExtender"/> class.
+    /// </summary>
+    /// <param name="hashAlgoName">The <see cref="HashAlgoName"/> that the CoseHashEnvelope will use.</param>
+    /// <param name="contentType">The content type of the original content being indirectly signed.</param>
+    /// <param name="payloadLocation">The optional payload location which will be stored in the protected header if presented.</param>
+    public CoseHashEnvelopeHeaderExtender(HashAlgorithmName hashAlgoName, string contentType, string? payloadLocation = null)
+    {
+        HashAlgoName = hashAlgoName;
+        if(string.IsNullOrWhiteSpace(contentType))
+        {
+            throw new ArgumentNullException(nameof(contentType));
+        }
+        ContentType = contentType;
+        PayloadLocation = payloadLocation;
+
+        if(!HashAlgorithmToCoseHeaderValue.ContainsKey(hashAlgoName))
+        {
+            throw new CoseIndirectSignatureException($"Unsupported hash algorithm in {nameof(CoseHashEnvelopeHeaderExtender)}: {hashAlgoName}");
+        }
+    }
+    /// <summary>
+    /// A dictionary of COSE Hash Envelope header labels and their corresponding CoseHeaderLabel values.
+    /// </summary>
+    public static readonly Dictionary<CoseHashEnvelopeHeaderLabels,CoseHeaderLabel> CoseHashEnvelopeHeaderLabels = new()
+    {
+        { CoseIndirectSignature.CoseHashEnvelopeHeaderLabels.PayloadHashAlg, new CoseHeaderLabel(258) }, // payload-hash-alg
+        { CoseIndirectSignature.CoseHashEnvelopeHeaderLabels.PreimageContentType, new CoseHeaderLabel(259) }, // preimage content type
+        { CoseIndirectSignature.CoseHashEnvelopeHeaderLabels.PayloadLocation, new CoseHeaderLabel(260) } // payload-location
+    };
+
+    /// <summary>
+    /// quick lookup of Cose Hash Algorithm name/value based on HashAlgorithmName
+    /// </summary>
+    private static readonly Dictionary<HashAlgorithmName, CoseHeaderValue> HashAlgorithmToCoseHeaderValue = new()
+    {
+        { HashAlgorithmName.SHA256, CoseHeaderValue.FromInt32((int)CoseHashAlgorithm.SHA256) },
+        { HashAlgorithmName.SHA384, CoseHeaderValue.FromInt32((int)CoseHashAlgorithm.SHA384) },
+        { HashAlgorithmName.SHA512, CoseHeaderValue.FromInt32((int)CoseHashAlgorithm.SHA512) }
+    };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// 3.  Header Parameters
+    /// This document specifies the following new header parameters commonly
+    /// used alongside hashes to identify resources:
+    /// 258:  the hash algorithm used to produce the payload.
+    /// 259:  the content type of the bytes that were hashed (preimage) to
+    ///   produce the payload, given as a content-format number
+    ///   (Section 12.3 of[RFC7252]) or as a media-type name optionally
+    ///   with parameters(Section 8.3 of[RFC9110]).
+    /// 260:  an identifier enabling retrieval of the original resource
+    ///   (preimage) identified by the payload.
+    /// </remarks>
+    public CoseHeaderMap ExtendProtectedHeaders(CoseHeaderMap protectedHeaders)
+    {
+        _ = protectedHeaders ?? throw new ArgumentNullException(nameof(protectedHeaders));
+
+        // Add the payload hash algorithm to the protected headers.
+        protectedHeaders.Add(
+            CoseHashEnvelopeHeaderLabels[CoseIndirectSignature.CoseHashEnvelopeHeaderLabels.PayloadHashAlg],
+            HashAlgorithmToCoseHeaderValue[this.HashAlgoName]
+        );
+
+        // Add the preimage content type to the protected headers.
+        protectedHeaders.Add(
+            CoseHashEnvelopeHeaderLabels[CoseIndirectSignature.CoseHashEnvelopeHeaderLabels.PreimageContentType],
+            CoseHeaderValue.FromString(ContentType)
+        );
+
+        // Add the payload location to the protected headers if it is not null.
+        if (PayloadLocation != null)
+        {
+            protectedHeaders.Add(
+                CoseHashEnvelopeHeaderLabels[CoseIndirectSignature.CoseHashEnvelopeHeaderLabels.PayloadLocation],
+                CoseHeaderValue.FromString(PayloadLocation)
+            );
+        }
+
+        // If the ContentType header is present, remove it.
+        if (protectedHeaders.ContainsKey(CoseHeaderLabel.ContentType))
+        {
+            /*
+               Label 3 (content_type) MUST NOT be present in the protected or
+                  unprotected headers.
+
+               Label 3 is easily confused with label TBD_2
+               payload_preimage_content_type.  The difference between content_type
+               (3) and payload_preimage_content_type (TBD2) is content_type is used
+               to identify the content format associated with payload, whereas
+               payload_preimage_content_type is used to identify the content format
+               of the bytes which are hashed to produce the payload.
+            */
+            protectedHeaders.Remove(CoseHeaderLabel.ContentType);
+        }
+
+        return protectedHeaders;
+    }
+
+    /// <inheritdoc />
+    public CoseHeaderMap ExtendUnProtectedHeaders(CoseHeaderMap? unProtectedHeaders)
+    {
+        if(unProtectedHeaders != null)
+        {
+            if(unProtectedHeaders.ContainsKey(CoseHeaderLabel.ContentType))
+            {
+                // If the ContentType header is present, remove it.
+                /*
+                   Label 3 (content_type) MUST NOT be present in the protected or
+                      unprotected headers.
+                */
+                unProtectedHeaders.Remove(CoseHeaderLabel.ContentType);
+            }
+            return unProtectedHeaders;
+        }
+        return [];
+    }
+}

--- a/CoseIndirectSignature/CoseHashV.cs
+++ b/CoseIndirectSignature/CoseHashV.cs
@@ -136,9 +136,9 @@ public record CoseHashV
         {
             throw new ArgumentOutOfRangeException(nameof(byteData), "The data to be hashed cannot be empty.");
         }
-        using HashAlgorithm hashAlgorightm = IndirectSignatureFactory.GetHashAlgorithmFromCoseHashAlgorithm(algorithm);
+        using HashAlgorithm hashAlgorithm = IndirectSignatureFactory.GetHashAlgorithmFromCoseHashAlgorithm(algorithm);
         // bypass the property setter since we are computing the hash value based on the algorithm directly.
-        InternalHashValue = hashAlgorightm.ComputeHash(byteData);
+        InternalHashValue = hashAlgorithm.ComputeHash(byteData);
     }
 
     /// <summary>

--- a/CoseIndirectSignature/CoseIndirectSignature.csproj
+++ b/CoseIndirectSignature/CoseIndirectSignature.csproj
@@ -42,6 +42,7 @@
 
 	<!--Project references-->
 	<ItemGroup>
+		<ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
 		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
 	</ItemGroup>
 

--- a/CoseIndirectSignature/CoseIndirectSignature.csproj
+++ b/CoseIndirectSignature/CoseIndirectSignature.csproj
@@ -37,7 +37,7 @@
 
 	<!--Package references-->
 	<ItemGroup>
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
 	</ItemGroup>
 
 	<!--Project references-->

--- a/CoseIndirectSignature/CoseIndirectSignature.csproj
+++ b/CoseIndirectSignature/CoseIndirectSignature.csproj
@@ -55,4 +55,12 @@
 		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>
+				CoseIndirectSignature.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9
+			</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
 </Project>

--- a/CoseIndirectSignature/Extensions/CoseSign1MessageCoseHashEnvelopeExtensions.cs
+++ b/CoseIndirectSignature/Extensions/CoseSign1MessageCoseHashEnvelopeExtensions.cs
@@ -15,7 +15,7 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
     /// https://datatracker.ietf.org/doc/draft-ietf-cose-hash-envelope/03/
     /// </summary>
     /// <param name="this">The <see cref="CoseSign1Message"/> to check.</param>
-    /// <returns>True if this is a CoseHashEnvelope @this, False otherwise.</returns>
+    /// <returns>True if <paramref name="this"/> is a CoseHashEnvelope, False otherwise.</returns>
     public static bool TryGetIsCoseHashEnvelope(this CoseSign1Message? @this)
     {
         if (@this == null)
@@ -30,7 +30,7 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
             return false;
         }
 
-        if(@this.TryGetPayloadHashAlgorithm(out _) != true)
+        if(!@this.TryGetPayloadHashAlgorithm(out _))
         {
             Trace.TraceWarning($"{nameof(TryGetIsCoseHashEnvelope)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the PayloadHashAlg header present.");
             return false;
@@ -46,23 +46,32 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
     /// <param name="this">The <see cref="CoseSign1Message"/> to be checked for PayloadHashAlgorithm protected header value.</param>
     /// <param name="payloadHashAlgorithm">ill be set to valid <see cref="CoseHashAlgorithm"/> if the return value is True. null otherwise.</param>
     /// <returns>True if the message has a valid PayloadHashAlgorithm header value, false otherwise.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="this"/> is null.</exception>
+    /// <remarks>Returns false if the value is found in the unprotected headers at all.</remarks>
     public static bool TryGetPayloadHashAlgorithm(this CoseSign1Message? @this, out CoseHashAlgorithm? payloadHashAlgorithm)
     {
         if (@this == null)
         {
             Trace.TraceError($"{nameof(TryGetPayloadHashAlgorithm)} was called on a null CoseSign1Message object");
-            throw new ArgumentNullException(nameof(@this));
+            payloadHashAlgorithm = null;
+            return false;
         }
+
         CoseHashAlgorithm? extractedValue = null;
-        // Label TBD_1(payload hash algorithm) MUST be present in the protected header
         // and MUST NOT be present in the unprotected header.
-        if (@this.ProtectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out CoseHeaderValue payloadHashAlgorithmValue))
+        if (@this.UnprotectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out CoseHeaderValue payloadHashAlgorithmValue))
+        {
+            Trace.TraceWarning($"{nameof(TryGetPayloadHashAlgorithm)} was called on a CoseSign1Message object({@this.GetHashCode()}) with the PayloadHashAlg present in unprotected headers which is not valid.");
+            payloadHashAlgorithm = null;
+            return false;
+        }
+
+        // Label TBD_1(payload hash algorithm) MUST be present in the protected header
+        if (@this.ProtectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out payloadHashAlgorithmValue))
         {
             extractedValue = GetCoseHashAlgorithmFromHeaderValue(payloadHashAlgorithmValue);
-            if (@this.UnprotectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out payloadHashAlgorithmValue))
+            if (extractedValue == null)
             {
-                Trace.TraceWarning($"{nameof(TryGetPayloadHashAlgorithm)} was called on a CoseSign1Message object({@this.GetHashCode()}) with the PayloadHashAlg present in unprotected headers which is not valid.");
+                Trace.TraceWarning($"{nameof(TryGetPayloadHashAlgorithm)} was called on a CoseSign1Message object({@this.GetHashCode()}) with the PayloadHashAlg header value not defined in the CoseHashAlgorithm enum.");
                 payloadHashAlgorithm = null;
                 return false;
             }
@@ -94,15 +103,15 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
     /// Tries to get the preimage content type from the headers of the CoseSign1Message.
     /// </summary>
     /// <param name="this">The <see cref="CoseSign1Message"/> to evaluate.</param>
-    /// <param name="preImageContentType"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <param name="preImageContentType">OUT param which will have the value of the PreImageContentType Cose Header.</param>
+    /// <returns>True if the PreImageContentType header is found and <paramref name="preImageContentType"/> will be non-null, False otherwise.</returns>
     public static bool TryGetPreImageContentType(this CoseSign1Message? @this, out string? preImageContentType)
     {
         if (@this == null)
         {
             Trace.TraceError($"{nameof(TryGetPayloadHashAlgorithm)} was called on a null CoseSign1Message object");
-            throw new ArgumentNullException(nameof(@this));
+            preImageContentType = null;
+            return false;
         }
 
         // Label TBD_2(content type of the preimage of the payload) MAY be
@@ -121,6 +130,7 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
             preImageContentType = preImageContentTypeValue.GetValueAsString();
             return true;
         }
+
         Trace.TraceWarning($"{nameof(TryGetPreImageContentType)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the PreimageContentType header present.");
         preImageContentType = null;
         return false;
@@ -129,16 +139,17 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
     /// <summary>
     /// Tries to get the payload location from the protected headers of the CoseSign1Message.
     /// </summary>
-    /// <param name="this"></param>
-    /// <param name="payloadLocation"></param>
+    /// <param name="this">The <see cref="CoseSign1Message"/> this extension method will apply to.</param>
+    /// <param name="payloadLocation">OUT reference to they payload location if the payload location is present in the <paramref name="this"/> message.</param>
     /// <returns>True if the payload location was extracted, false otherwise.</returns>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <remarks>Will also return False if the value is found in the unprotected header.</remarks>
     public static bool TryGetPayloadLocation(this CoseSign1Message? @this, out string? payloadLocation)
     {
         if (@this == null)
         {
             Trace.TraceError($"{nameof(TryGetPayloadHashAlgorithm)} was called on a null CoseSign1Message object");
-            throw new ArgumentNullException(nameof(@this));
+            payloadLocation = null;
+            return false;
         }
 
         // Label TBD_3(payload_location) MAY be added to the protected
@@ -167,10 +178,11 @@ public static class CoseSign1MessageCoseHashEnvelopeExtensions
     /// Leverages the CoseHashEnvelope rules to validate content against the stored indirect hash of the content.
     /// </summary>
     /// <remarks>https://datatracker.ietf.org/doc/draft-ietf-cose-hash-envelope/03/</remarks>
-    /// <param name="this">The CoseSign1Message to evaluate the CoseHashEnvelope structure</param>
+    /// <param name="this">The <see cref="CoseSign1Message"/> to evaluate the CoseHashEnvelope structure</param>
     /// <param name="artifactBytes">The artifact bytes to evaluate.</param>
     /// <param name="artifactStream">The artifact stream to evaluate.</param>
     /// <exception cref="InvalidCoseDataException">Thrown if the <paramref name="this"/> object is not a valid CoseHashEnvelope message.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="this"/> is null.</exception>
     /// <returns>True if the Indirect signature in the CoseSign1Message matches the signature of the artifact bytes; False otherwise.</returns>
     internal static bool SignatureMatchesInternalCoseHashEnvelope(this CoseSign1Message @this, ReadOnlyMemory<byte>? artifactBytes = null, Stream? artifactStream = null)
     {

--- a/CoseIndirectSignature/Extensions/CoseSign1MessageCoseHashEnvelopeExtensions.cs
+++ b/CoseIndirectSignature/Extensions/CoseSign1MessageCoseHashEnvelopeExtensions.cs
@@ -1,0 +1,200 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature.Extensions;
+
+using System;
+
+/// <summary>
+/// Extensions for <see cref="CoseSign1Message"/> to support COSE Hash Envelope.
+/// </summary>
+public static class CoseSign1MessageCoseHashEnvelopeExtensions
+{
+    /// <summary>
+    /// Checks to see if the COSE Sign1 Message is a CoseHashEnvelope.
+    /// https://datatracker.ietf.org/doc/draft-ietf-cose-hash-envelope/03/
+    /// </summary>
+    /// <param name="this">The <see cref="CoseSign1Message"/> to check.</param>
+    /// <returns>True if this is a CoseHashEnvelope @this, False otherwise.</returns>
+    public static bool TryGetIsCoseHashEnvelope(this CoseSign1Message? @this)
+    {
+        if (@this == null)
+        {
+            Trace.TraceError($"{nameof(TryGetIsCoseHashEnvelope)} was called on a null CoseSign1Message object");
+            return false;
+        }
+
+        if (@this.Content == null)
+        {
+            Trace.TraceWarning($"{nameof(TryGetIsCoseHashEnvelope)} was called on a detached CoseSign1Message object, which is not valid.");
+            return false;
+        }
+
+        if(@this.TryGetPayloadHashAlgorithm(out _) != true)
+        {
+            Trace.TraceWarning($"{nameof(TryGetIsCoseHashEnvelope)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the PayloadHashAlg header present.");
+            return false;
+        }
+
+        // This is a CoseHashEnvelope CoseSign1Message.
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to get the payload hash algorithm from the protected headers of the CoseSign1Message.
+    /// </summary>
+    /// <param name="this">The <see cref="CoseSign1Message"/> to be checked for PayloadHashAlgorithm protected header value.</param>
+    /// <param name="payloadHashAlgorithm">ill be set to valid <see cref="CoseHashAlgorithm"/> if the return value is True. null otherwise.</param>
+    /// <returns>True if the message has a valid PayloadHashAlgorithm header value, false otherwise.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="this"/> is null.</exception>
+    public static bool TryGetPayloadHashAlgorithm(this CoseSign1Message? @this, out CoseHashAlgorithm? payloadHashAlgorithm)
+    {
+        if (@this == null)
+        {
+            Trace.TraceError($"{nameof(TryGetPayloadHashAlgorithm)} was called on a null CoseSign1Message object");
+            throw new ArgumentNullException(nameof(@this));
+        }
+        CoseHashAlgorithm? extractedValue = null;
+        // Label TBD_1(payload hash algorithm) MUST be present in the protected header
+        // and MUST NOT be present in the unprotected header.
+        if (@this.ProtectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out CoseHeaderValue payloadHashAlgorithmValue))
+        {
+            extractedValue = GetCoseHashAlgorithmFromHeaderValue(payloadHashAlgorithmValue);
+            if (@this.UnprotectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out payloadHashAlgorithmValue))
+            {
+                Trace.TraceWarning($"{nameof(TryGetPayloadHashAlgorithm)} was called on a CoseSign1Message object({@this.GetHashCode()}) with the PayloadHashAlg present in unprotected headers which is not valid.");
+                payloadHashAlgorithm = null;
+                return false;
+            }
+
+            payloadHashAlgorithm = extractedValue;
+            return true;
+        }
+
+        Trace.TraceWarning($"{nameof(TryGetPayloadHashAlgorithm)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the PayloadHashAlg protected header present.");
+        payloadHashAlgorithm = null;
+        return false;
+    }
+
+    private static CoseHashAlgorithm? GetCoseHashAlgorithmFromHeaderValue(CoseHeaderValue payloadHeaderValue)
+    {
+        long value = payloadHeaderValue.GetValueAsInt32();
+        if (Enum.IsDefined(typeof(CoseHashAlgorithm), value))
+        {
+            return (CoseHashAlgorithm)value;
+        }
+        else
+        {
+            Trace.TraceWarning($"Value {value} is not defined in the CoseHashAlgorithm enum.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Tries to get the preimage content type from the headers of the CoseSign1Message.
+    /// </summary>
+    /// <param name="this">The <see cref="CoseSign1Message"/> to evaluate.</param>
+    /// <param name="preImageContentType"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static bool TryGetPreImageContentType(this CoseSign1Message? @this, out string? preImageContentType)
+    {
+        if (@this == null)
+        {
+            Trace.TraceError($"{nameof(TryGetPayloadHashAlgorithm)} was called on a null CoseSign1Message object");
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        // Label TBD_2(content type of the preimage of the payload) MAY be
+        // present in the protected header or unprotected header.
+
+        // first check protected headers as its preferred to be present there
+        if (@this.ProtectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PreimageContentType], out CoseHeaderValue preImageContentTypeValue))
+        {
+            preImageContentType = preImageContentTypeValue.GetValueAsString();
+            return true;
+        }
+
+        // second check unprotected headers
+        if (@this.UnprotectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PreimageContentType], out preImageContentTypeValue))
+        {
+            preImageContentType = preImageContentTypeValue.GetValueAsString();
+            return true;
+        }
+        Trace.TraceWarning($"{nameof(TryGetPreImageContentType)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the PreimageContentType header present.");
+        preImageContentType = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get the payload location from the protected headers of the CoseSign1Message.
+    /// </summary>
+    /// <param name="this"></param>
+    /// <param name="payloadLocation"></param>
+    /// <returns>True if the payload location was extracted, false otherwise.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static bool TryGetPayloadLocation(this CoseSign1Message? @this, out string? payloadLocation)
+    {
+        if (@this == null)
+        {
+            Trace.TraceError($"{nameof(TryGetPayloadHashAlgorithm)} was called on a null CoseSign1Message object");
+            throw new ArgumentNullException(nameof(@this));
+        }
+
+        // Label TBD_3(payload_location) MAY be added to the protected
+        // header and MUST NOT be presented in the unprotected header.
+
+        if(@this.UnprotectedHeaders?.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadLocation], out CoseHeaderValue payloadLocationValue) ?? false)
+        {
+            // If the payload location is present in the unprotected headers, return false.
+            Trace.TraceWarning($"{nameof(TryGetPayloadLocation)} was called on a CoseSign1Message object({@this.GetHashCode()}) with the PayloadLocation present in unprotected headers which is not valid.");
+            payloadLocation = null;
+            return false;
+        }
+
+        if (@this.ProtectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadLocation], out payloadLocationValue))
+        {
+            payloadLocation = payloadLocationValue.GetValueAsString();
+            return true;
+        }
+
+        Trace.TraceWarning($"{nameof(TryGetPayloadLocation)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the PayloadLocation header present.");
+        payloadLocation = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Leverages the CoseHashEnvelope rules to validate content against the stored indirect hash of the content.
+    /// </summary>
+    /// <remarks>https://datatracker.ietf.org/doc/draft-ietf-cose-hash-envelope/03/</remarks>
+    /// <param name="this">The CoseSign1Message to evaluate the CoseHashEnvelope structure</param>
+    /// <param name="artifactBytes">The artifact bytes to evaluate.</param>
+    /// <param name="artifactStream">The artifact stream to evaluate.</param>
+    /// <exception cref="InvalidCoseDataException">Thrown if the <paramref name="this"/> object is not a valid CoseHashEnvelope message.</exception>
+    /// <returns>True if the Indirect signature in the CoseSign1Message matches the signature of the artifact bytes; False otherwise.</returns>
+    internal static bool SignatureMatchesInternalCoseHashEnvelope(this CoseSign1Message @this, ReadOnlyMemory<byte>? artifactBytes = null, Stream? artifactStream = null)
+    {
+        if (@this == null)
+        {
+            Trace.TraceError($"{nameof(SignatureMatchesInternalCoseHashEnvelope)} was called on a null CoseSign1Message object");
+            throw new ArgumentNullException(nameof(@this));
+        }
+        _ = @this.ProtectedHeaders.TryGetValue(CoseHashEnvelopeHeaderExtender.CoseHashEnvelopeHeaderLabels[CoseHashEnvelopeHeaderLabels.PayloadHashAlg], out CoseHeaderValue hashAlgValue);
+        CoseHashAlgorithm? hashAlg = GetCoseHashAlgorithmFromHeaderValue(hashAlgValue);
+        if (hashAlg == null)
+        {
+            string logMessage = $"The CoseSign1Message[{@this?.GetHashCode()}] object does not contain a valid PayloadHashAlg header value.";
+            Trace.TraceWarning(logMessage);
+            throw new InvalidCoseDataException(logMessage);
+        }
+
+        if(@this.Content == null || @this.Content.Value.Length == 0)
+        {
+            string logMessage = $"The CoseSign1Message[{@this?.GetHashCode()}] object does not contain a valid Content value for CoseHashEnvelope usage.";
+            Trace.TraceWarning(logMessage);
+            throw new InvalidCoseDataException(logMessage);
+        }
+
+        return IndirectSignatureFactory.HashMatches((CoseHashAlgorithm)hashAlg, @this.Content.Value, artifactBytes, artifactStream);
+    }
+}

--- a/CoseIndirectSignature/Extensions/CoseSign1MessageCoseHashVExtensions.cs
+++ b/CoseIndirectSignature/Extensions/CoseSign1MessageCoseHashVExtensions.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature.Extensions;
+
+/// <summary>
+/// Extensions for <see cref="CoseSign1Message"/> to support COSE Hash V.
+/// </summary>
+public static class CoseSign1MessageCoseHashVExtensions
+{
+    /// <summary>
+    /// Regex to match the +cose-hash-v content/mime type extension.
+    /// </summary>
+    private static readonly Regex CoseHashVMimeTypeExtension = new(@$"\+cose-hash-v", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Checks to see if a COSE Sign1 Message has the Content Type Protected Header set to include +cose-hash-v
+    /// </summary>
+    /// <param name="this">The CoseSign1Message to evaluate</param>
+    /// <returns>True if +cose-hash-v is found, False otherwise.</returns>
+    public static bool TryGetIsCoseHashVContentType(this CoseSign1Message? @this)
+    {
+        if (@this == null)
+        {
+            Trace.TraceError($"{nameof(TryGetIsCoseHashVContentType)} was called on a null CoseSign1Message object");
+            return false;
+        }
+
+        if (@this.Content == null)
+        {
+            Trace.TraceWarning($"{nameof(TryGetIsCoseHashVContentType)} was called on a detached CoseSign1Message object, which is not valid.");
+            return false;
+        }
+
+        if (!@this.ProtectedHeaders.TryGetValue(CoseHeaderLabel.ContentType, out CoseHeaderValue contentTypeValue))
+        {
+            Trace.TraceWarning($"{nameof(TryGetIsCoseHashVContentType)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the ContentType protected header present.");
+            return false;
+        }
+
+        string contentType = contentTypeValue.GetValueAsString();
+        if (string.IsNullOrEmpty(contentType))
+        {
+            Trace.TraceWarning($"{nameof(TryGetIsCoseHashVContentType)} was called on a CoseSign1Message object({@this.GetHashCode()}) without the ContentType protected header being a string value.");
+            return false;
+        }
+
+        Match mimeMatch = CoseHashVMimeTypeExtension.Match(contentType);
+        return mimeMatch.Success;
+    }
+
+    /// <summary>
+    /// Returns the CoseHashV object contained within the .Content of the CoseSign1Message if it is a CoseHashV encoded message.
+    /// </summary>
+    /// <param name="this">The CoseSign1Message to evaluate.</param>
+    /// <param name="disableValidation">True to disable the checks which ensure the decoded algorithm expected hash length and the length of the decoded hash match, False (default) to leave them enabled.</param>
+    /// <returns>A deserialized CoseHashV object if no errors, an exception otherwise.</returns>
+    /// <exception cref="InvalidDataException">Thrown if the CoseSign1Message is not a CoseHashV capable object.</exception>
+    /// <exception cref="InvalidCoseDataException">Thrown if the content of this CoseSign1Message cannot be deserialized into a CoseHashV object.</exception>
+    public static CoseHashV GetCoseHashV(this CoseSign1Message @this, bool disableValidation = false)
+    {
+        return !@this.TryGetIsCoseHashVContentType()
+            ? throw new InvalidDataException($"The CoseSign1Message[{@this?.GetHashCode()}] object is not a CoseHashV capable object.")
+            : CoseHashV.Deserialize(@this!.Content.Value, disableValidation);
+    }
+
+    /// <summary>
+    /// Returns true and populates indirectHash with the CoseHashV object contained within the .Content of the CoseSign1Message if it is a CoseHashV encoded message, false otherwise.
+    /// </summary>
+    /// <param name="this">The CoseSign1Message to evaluate.</param>
+    /// <param name="disableValidation">True to disable the checks which ensure the decoded algorithm expected hash length and the length of the decoded hash match, False (default) to leave them enabled.</param>
+    /// <returns>True if indirectHash is successfully populated, false otherwise.</returns>
+    public static bool TryGetCoseHashV(this CoseSign1Message @this, out CoseHashV? indirectHash, bool disableValidation = false)
+    {
+        indirectHash = null;
+
+        try
+        {
+            indirectHash = @this.GetCoseHashV(disableValidation: disableValidation);
+        }
+        catch (Exception ex) when (ex is InvalidDataException || ex is InvalidCoseDataException)
+        {
+            Trace.TraceWarning($"Attempting to get CoseHashV from CoseSign1Message[{@this?.GetHashCode()}] failed, returning false.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Leverages the CoseHashV structure path to validate content against the stored indirect hash of the content.
+    /// </summary>
+    /// <param name="this">The CoseSign1Message to evaluate the CoseHashV structure from .Content</param>
+    /// <param name="artifactBytes">The artifact bytes to evaluate.</param>
+    /// <param name="artifactStream">The artifact stream to evaluate.</param>
+    /// <returns>True if the Indirect signature in the CoseSign1Message matches the signature of the artifact bytes; False otherwise.</returns>
+    internal static bool SignatureMatchesInternalCoseHashV(this CoseSign1Message @this, ReadOnlyMemory<byte>? artifactBytes = null, Stream? artifactStream = null)
+    {
+        CoseHashV hashStructure = CoseHashV.Deserialize(@this.Content.Value);
+        return artifactStream != null
+                              ? hashStructure.ContentMatches(artifactStream)
+                              : hashStructure.ContentMatches(artifactBytes!.Value);
+    }
+}

--- a/CoseIndirectSignature/IndirectSignatureFactory.Bytes.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.Bytes.cs
@@ -1,0 +1,410 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature;
+
+/// <summary>
+/// Byte methods and overloads for the IndirectSignatureFactory class.
+/// </summary>
+public sealed partial class IndirectSignatureFactory
+{
+    #region ReadonlyMemory<byte> overloads return CoseSign1Message
+    #region sync old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public CoseSign1Message CreateIndirectSignature(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignature(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                    ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                    : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public CoseSign1Message CreateIndirectSignatureFromHash(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureFromHash(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                    ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                    : IndirectSignatureVersion.CoseHashEnvelope);
+    #endregion
+    #region async old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureAsync(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureAsync(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureFromHashAsync(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureFromHashAsync(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                    ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                    : IndirectSignatureVersion.CoseHashEnvelope);
+
+    #endregion
+    #region sync new signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public CoseSign1Message CreateIndirectSignature(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: false,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                bytePayload: payload,
+                signatureVersion: signatureVersion);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public CoseSign1Message CreateIndirectSignatureFromHash(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: false,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                bytePayload: rawHash,
+                payloadHashed: true,
+                signatureVersion: signatureVersion);
+    #endregion
+    #region async new signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create..</param>
+    /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureAsync(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: false,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    bytePayload: payload,
+                    signatureVersion: signatureVersion));
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureFromHashAsync(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: false,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    bytePayload: rawHash,
+                    payloadHashed: true,
+                    signatureVersion: signatureVersion));
+    #endregion
+    #endregion
+
+    #region Readonly<byte> overloads return byte[]
+    #region sync old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytes(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytes(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytesFromHash(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytesFromHash(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+    #endregion
+    #region async old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesAsync(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytesAsync(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesFromHashAsync(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytesFromHashAsync(
+                    rawHash: rawHash,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    signatureVersion:
+                        useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                            ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                            : IndirectSignatureVersion.CoseHashEnvelope);
+    #endregion
+    #region sync new signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytes(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: true,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                bytePayload: payload,
+                signatureVersion: signatureVersion);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytesFromHash(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: true,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                bytePayload: rawHash,
+                payloadHashed: true,
+                signatureVersion: signatureVersion);
+    #endregion
+
+    #region async old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesAsync(
+        ReadOnlyMemory<byte> payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: true,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    bytePayload: payload,
+                    signatureVersion: signatureVersion));
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesFromHashAsync(
+        ReadOnlyMemory<byte> rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: true,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    bytePayload: rawHash,
+                    payloadHashed: true,
+                    signatureVersion: signatureVersion));
+    #endregion
+    #endregion
+}

--- a/CoseIndirectSignature/IndirectSignatureFactory.CoseHashEnvelope.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.CoseHashEnvelope.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature;
+
+/// <summary>
+/// Methods to create indirect signatures in the COSE Hash Envelope format.
+/// </summary>
+public sealed partial class IndirectSignatureFactory
+{
+    /// <summary>
+    /// Does the heavy lifting for this class in computing the hash and creating the correct representation of the CoseSign1Message base on input
+    /// for https://datatracker.ietf.org/doc/draft-ietf-cose-hash-envelope/03/
+    /// </summary>
+    /// <param name="returnBytes">True if ReadOnlyMemory<byte> form of CoseSign1Message is to be returned, False for a proper CoseSign1Message</param>
+    /// <param name="signingKeyProvider">The signing key provider used for COSE signing operations.</param>
+    /// <param name="contentType">The user specified content type.</param>
+    /// <param name="streamPayload">If not null, then Stream API's on the CoseSign1MessageFactory are used.</param>
+    /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
+    /// <param name="payloadHashed">True if the payload represents the raw hash</param>
+    /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
+    /// <exception cref="ArgumentException">payloadHashed is set, but hash size does not correspond to any known hash algorithms</exception>
+    private object CreateIndirectSignatureWithChecksInternalCoseHashEnvelopeFormat(
+        bool returnBytes,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        Stream? streamPayload = null,
+        ReadOnlyMemory<byte>? bytePayload = null,
+        bool payloadHashed = false)
+    {
+        ReadOnlyMemory<byte> hash;
+        HashAlgorithmName algoName = InternalHashAlgorithmName;
+
+        if (!payloadHashed)
+        {
+            hash = streamPayload != null
+                                 ? InternalHashAlgorithm.ComputeHash(streamPayload)
+                                 : InternalHashAlgorithm.ComputeHash(bytePayload!.Value.ToArray());
+        }
+        else
+        {
+            hash = streamPayload != null
+                                 ? streamPayload.GetBytes()
+                                 : bytePayload!.Value.ToArray();
+            try
+            {
+                algoName = SizeInBytesToAlgorithm[hash.Length];
+            }
+            catch (KeyNotFoundException e)
+            {
+                throw new ArgumentException($"{nameof(payloadHashed)} is set, but payload size does not correspond to any known hash sizes in {nameof(HashAlgorithmName)}", e);
+            }
+        }
+
+        return returnBytes
+               ? InternalMessageFactory.CreateCoseSign1MessageBytes(
+                    hash,
+                    signingKeyProvider,
+                    embedPayload: true,
+                    headerExtender: new CoseHashEnvelopeHeaderExtender(algoName, contentType, null))
+               : InternalMessageFactory.CreateCoseSign1Message(
+                    hash,
+                    signingKeyProvider,
+                    embedPayload: true,
+                    headerExtender: new CoseHashEnvelopeHeaderExtender(algoName, contentType, null));
+    }
+}

--- a/CoseIndirectSignature/IndirectSignatureFactory.CoseHashV.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.CoseHashV.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature;
+
+/// <summary>
+/// Methods to create indirect signatures in the COSE Hash V format.
+/// </summary>
+public sealed partial class IndirectSignatureFactory
+{
+    /// <summary>
+    /// Does the heavy lifting for this class in computing the hash and creating the correct representation of the CoseSign1Message base on input.
+    /// </summary>
+    /// <param name="returnBytes">True if ReadOnlyMemory<byte> form of CoseSign1Message is to be returned, False for a proper CoseSign1Message</param>
+    /// <param name="signingKeyProvider">The signing key provider used for COSE signing operations.</param>
+    /// <param name="contentType">The user specified content type.</param>
+    /// <param name="streamPayload">If not null, then Stream API's on the CoseSign1MessageFactory are used.</param>
+    /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
+    /// <param name="payloadHashed">True if the payload represents the raw hash</param>
+    /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
+    /// <exception cref="ArgumentException">payloadHashed is set, but hash size does not correspond to any known hash algorithms</exception>
+    private object CreateIndirectSignatureWithChecksInternalCoseHashVFormat(
+        bool returnBytes,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        Stream? streamPayload = null,
+        ReadOnlyMemory<byte>? bytePayload = null,
+        bool payloadHashed = false)
+    {
+        CoseHashV hash;
+        string extendedContentType = ExtendContentTypeCoseHashV(contentType);
+        if (!payloadHashed)
+        {
+            hash = streamPayload != null
+                                 ? new CoseHashV(InternalCoseHashAlgorithm, streamPayload)
+                                 : new CoseHashV(InternalCoseHashAlgorithm, bytePayload!.Value);
+        }
+        else
+        {
+            byte[] rawHash = streamPayload != null
+                                           ? streamPayload.GetBytes()
+                                           : bytePayload!.Value.ToArray();
+
+            if (rawHash.Length != HashLength)
+            {
+                throw new ArgumentException($"{nameof(payloadHashed)} is set, but payload length {rawHash.Length} does not correspond to the hash size for {InternalHashAlgorithmName} of {HashLength}.");
+            }
+
+            hash = new CoseHashV
+            {
+                Algorithm = InternalCoseHashAlgorithm,
+                HashValue = rawHash
+            };
+        }
+
+        return returnBytes
+               // return the raw bytes if asked
+               ? InternalMessageFactory.CreateCoseSign1MessageBytes(
+                    hash.Serialize(),
+                    signingKeyProvider,
+                    embedPayload: true,
+                    contentType: extendedContentType)
+               // return the CoseSign1Message object
+               : InternalMessageFactory.CreateCoseSign1Message(
+                    hash.Serialize(),
+                    signingKeyProvider,
+                    embedPayload: true,
+                    contentType: extendedContentType);
+    }
+
+    /// <summary>
+    /// Method which produces a mime type extension for cose_hash_v
+    /// </summary>
+    /// <param name="contentType">The content type to append the cose_hash_v extension to if not already appended.</param>
+    /// <returns>A string representing the content type with an appended cose_hash_v extension</returns>
+    private static string ExtendContentTypeCoseHashV(string contentType)
+    {
+        // only add the extension mapping, if it's not already present within the contentType
+        bool alreadyPresent = contentType.IndexOf("+cose-hash-v", StringComparison.InvariantCultureIgnoreCase) != -1;
+
+        return alreadyPresent
+            ? contentType
+            : $"{contentType}+cose-hash-v";
+    }
+}

--- a/CoseIndirectSignature/IndirectSignatureFactory.Direct.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.Direct.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature;
+
+/// <summary>
+/// Methods to create indirect signatures in the original direct hash format.
+/// </summary>
+public sealed partial class IndirectSignatureFactory
+{
+    /// <summary>
+    /// Does the heavy lifting for this class in computing the hash and creating the correct representation of the CoseSign1Message base on input.
+    /// </summary>
+    /// <param name="returnBytes">True if ReadOnlyMemory<byte> form of CoseSign1Message is to be returned, False for a proper CoseSign1Message</param>
+    /// <param name="signingKeyProvider">The signing key provider used for COSE signing operations.</param>
+    /// <param name="contentType">The user specified content type.</param>
+    /// <param name="streamPayload">If not null, then Stream API's on the CoseSign1MessageFactory are used.</param>
+    /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
+    /// <param name="payloadHashed">True if the payload represents the raw hash</param>
+    /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
+    /// <exception cref="ArgumentException">payloadHashed is set, but hash size does not correspond to any known hash algorithms</exception>
+    private object CreateIndirectSignatureWithChecksInternalDirectFormat(
+        bool returnBytes,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        Stream? streamPayload = null,
+        ReadOnlyMemory<byte>? bytePayload = null,
+        bool payloadHashed = false)
+    {
+        ReadOnlyMemory<byte> hash;
+        string extendedContentType;
+        if (!payloadHashed)
+        {
+            hash = streamPayload != null
+                                 ? InternalHashAlgorithm.ComputeHash(streamPayload)
+                                 : InternalHashAlgorithm.ComputeHash(bytePayload!.Value.ToArray());
+            extendedContentType = ExtendContentTypeDirect(contentType, HashAlgorithmName);
+        }
+        else
+        {
+            hash = streamPayload != null
+                                 ? streamPayload.GetBytes()
+                                 : bytePayload!.Value.ToArray();
+            try
+            {
+                HashAlgorithmName algoName = SizeInBytesToAlgorithm[hash.Length];
+                extendedContentType = ExtendContentTypeDirect(contentType, algoName);
+            }
+            catch (KeyNotFoundException e)
+            {
+                throw new ArgumentException($"{nameof(payloadHashed)} is set, but payload size does not correspond to any known hash sizes in {nameof(HashAlgorithmName)}", e);
+            }
+        }
+
+        return returnBytes
+               ? InternalMessageFactory.CreateCoseSign1MessageBytes(
+                    hash,
+                    signingKeyProvider,
+                    embedPayload: true,
+                    contentType: extendedContentType)
+               : InternalMessageFactory.CreateCoseSign1Message(
+                    hash,
+                    signingKeyProvider,
+                    embedPayload: true,
+                    contentType: extendedContentType);
+    }
+
+    /// <summary>
+    /// Method which produces a mime type extension based on the given content type and hash algorithm name.
+    /// </summary>
+    /// <param name="contentType">The content type to append the hash value to if not already appended.</param>
+    /// <param name="algorithmName">The "HashAlgorithmName" to append if not already appended.</param>
+    /// <returns>A string representing the content type with an appended hash algorithm</returns>
+    private static string ExtendContentTypeDirect(string contentType, HashAlgorithmName algorithmName)
+    {
+        // extract from the string cache to keep string allocations down.
+        string extensionMapping = DirectContentTypeExtensionMap.GetOrAdd(algorithmName.Name, (name) => $"+hash-{name.ToLowerInvariant()}");
+
+        // only add the extension mapping, if it's not already present within the contentType
+        bool alreadyPresent = contentType.IndexOf("+hash-", StringComparison.InvariantCultureIgnoreCase) != -1;
+
+        return alreadyPresent
+            ? contentType
+            : $"{contentType}{extensionMapping}";
+    }
+
+    /// <summary>
+    /// quick lookup map between algorithm name and mime extension
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, string> DirectContentTypeExtensionMap = new(
+        new Dictionary<string, string>()
+        {
+            { HashAlgorithmName.SHA256.Name, "+hash-sha256" },
+            { HashAlgorithmName.SHA384.Name, "+hash-sha384" },
+            { HashAlgorithmName.SHA512.Name, "+hash-sha512" }
+        });
+}

--- a/CoseIndirectSignature/IndirectSignatureFactory.Stream.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.Stream.cs
@@ -1,0 +1,409 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseIndirectSignature;
+
+/// <summary>
+/// Stream methods and overloads for the IndirectSignatureFactory class.
+/// </summary>
+public sealed partial class IndirectSignatureFactory
+{
+    #region Stream overloads return CoseSign1Message
+    #region sync old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public CoseSign1Message CreateIndirectSignature(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignature(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public CoseSign1Message CreateIndirectSignatureFromHash(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureFromHash(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureAsync(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureAsync(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureFromHashAsync(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureFromHashAsync(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+    #endregion
+    #region new sync signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public CoseSign1Message CreateIndirectSignature(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: false,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                streamPayload: payload,
+                signatureVersion: signatureVersion);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public CoseSign1Message CreateIndirectSignatureFromHash(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: false,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                streamPayload: rawHash,
+                payloadHashed: true,
+                signatureVersion: signatureVersion);
+    #endregion
+    #region new async signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureAsync(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: false,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    streamPayload: payload,
+                    signatureVersion: signatureVersion));
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<CoseSign1Message> CreateIndirectSignatureFromHashAsync(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: false,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    streamPayload: rawHash,
+                    payloadHashed: true,
+                    signatureVersion: signatureVersion));
+    #endregion
+    #endregion
+
+    #region Stream overloads return byte[]
+    #region sync old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytes(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytes(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytesFromHash(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytesFromHash(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+    #endregion
+    #region async old signature - backwards compatibility
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesAsync(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytesAsync(
+                payload: payload,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesFromHashAsync(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        bool useOldFormat = false) =>
+            CreateIndirectSignatureBytesFromHashAsync(
+                rawHash: rawHash,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                signatureVersion:
+                    useOldFormat
+#pragma warning disable CS0618 // Type or member is obsolete
+                        ? IndirectSignatureVersion.CoseHashV
+#pragma warning restore CS0618 // Type or member is obsolete
+                        : IndirectSignatureVersion.CoseHashEnvelope);
+    #endregion
+    #region new sync signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytes(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: true,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                streamPayload: payload,
+                payloadHashed: false,
+                signatureVersion: signatureVersion);
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public ReadOnlyMemory<byte> CreateIndirectSignatureBytesFromHash(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                returnBytes: true,
+                signingKeyProvider: signingKeyProvider,
+                contentType: contentType,
+                streamPayload: rawHash,
+                payloadHashed: true,
+                signatureVersion: signatureVersion);
+    #endregion
+    #region new async signature
+    /// <summary>
+    /// Creates a Indirect signature of the specified payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="payload">The payload to create a Indirect signature for.</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesAsync(
+        Stream payload,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: true,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    streamPayload: payload,
+                    payloadHashed: false,
+                    signatureVersion: signatureVersion));
+
+    /// <summary>
+    /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
+    /// </summary>
+    /// <param name="rawHash">The raw hash of the payload</param>
+    /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
+    /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
+    /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
+    /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
+    /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
+    public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesFromHashAsync(
+        Stream rawHash,
+        ICoseSigningKeyProvider signingKeyProvider,
+        string contentType,
+        IndirectSignatureVersion signatureVersion) =>
+            Task.FromResult(
+                (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
+                    returnBytes: true,
+                    signingKeyProvider: signingKeyProvider,
+                    contentType: contentType,
+                    streamPayload: rawHash,
+                    payloadHashed: true,
+                    signatureVersion: signatureVersion));
+    #endregion
+    #endregion
+}

--- a/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
+++ b/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
@@ -37,7 +37,7 @@
 
 	<!--Package references-->
 	<ItemGroup>
-		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="9.0.2" />
 	</ItemGroup>
 
 	<!--Files to include in the package-->

--- a/CoseSign1.Certificates/CoseSign1.Certificates.csproj
+++ b/CoseSign1.Certificates/CoseSign1.Certificates.csproj
@@ -36,7 +36,7 @@
 
 	<!--Package references-->
 	<ItemGroup>
-		<PackageReference Include="System.Runtime.Caching" Version="8.0.1" />
+		<PackageReference Include="System.Runtime.Caching" Version="9.0.2" />
 	</ItemGroup>
 
 	<!--Project references-->

--- a/CoseSign1.Tests/CoseSign1.Tests.csproj
+++ b/CoseSign1.Tests/CoseSign1.Tests.csproj
@@ -32,8 +32,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Formats.Cbor" Version="7.0.0" />
-		<PackageReference Include="System.Security.Cryptography.Cose" Version="7.0.0" />
+		<PackageReference Include="System.Security.Cryptography.Cose" Version="9.0.2" />
 	</ItemGroup>
 
 	<!-- Project references -->

--- a/CoseSign1/CoseSign1MessageFactory.cs
+++ b/CoseSign1/CoseSign1MessageFactory.cs
@@ -24,7 +24,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string contentType = DEFAULT_CONTENT_TYPE,
+        string? contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null
            )
     {
@@ -37,7 +37,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string contentType = DEFAULT_CONTENT_TYPE,
+        string? contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         ReadOnlyMemory<byte> serializedMsg = CreateCoseSign1MessageBytes(payload, signingKeyProvider, embedPayload, contentType, headerExtender);
@@ -49,7 +49,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string contentType = DEFAULT_CONTENT_TYPE,
+        string? contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         CoseSigner signer = GetSigner(signingKeyProvider, contentType, headerExtender);
@@ -65,7 +65,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string contentType = DEFAULT_CONTENT_TYPE,
+        string? contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         CoseSigner signer = GetSigner(signingKeyProvider, contentType, headerExtender);
@@ -79,7 +79,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
     // Generate a CoseSigner object from the SigningKeyProvider, content type, and HeaderExtender
     private static CoseSigner GetSigner(
         ICoseSigningKeyProvider signingKeyProvider,
-        string contentType = DEFAULT_CONTENT_TYPE,
+        string? contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         // Make sure we have something to sign with.

--- a/CoseSign1/CoseSign1MessageFactory.cs
+++ b/CoseSign1/CoseSign1MessageFactory.cs
@@ -24,7 +24,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string? contentType = DEFAULT_CONTENT_TYPE,
+        string contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null
            )
     {
@@ -37,7 +37,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string? contentType = DEFAULT_CONTENT_TYPE,
+        string contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         ReadOnlyMemory<byte> serializedMsg = CreateCoseSign1MessageBytes(payload, signingKeyProvider, embedPayload, contentType, headerExtender);
@@ -49,7 +49,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string? contentType = DEFAULT_CONTENT_TYPE,
+        string contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         CoseSigner signer = GetSigner(signingKeyProvider, contentType, headerExtender);
@@ -65,7 +65,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
         Stream payload,
         ICoseSigningKeyProvider signingKeyProvider,
         bool embedPayload = false,
-        string? contentType = DEFAULT_CONTENT_TYPE,
+        string contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         CoseSigner signer = GetSigner(signingKeyProvider, contentType, headerExtender);
@@ -79,7 +79,7 @@ public sealed class CoseSign1MessageFactory : ICoseSign1MessageFactory
     // Generate a CoseSigner object from the SigningKeyProvider, content type, and HeaderExtender
     private static CoseSigner GetSigner(
         ICoseSigningKeyProvider signingKeyProvider,
-        string? contentType = DEFAULT_CONTENT_TYPE,
+        string contentType = DEFAULT_CONTENT_TYPE,
         ICoseHeaderExtender? headerExtender = null)
     {
         // Make sure we have something to sign with.

--- a/CoseSignTool.Tests/MainTests.cs
+++ b/CoseSignTool.Tests/MainTests.cs
@@ -9,12 +9,9 @@ public class MainTests
     // Certificates
     private static readonly X509Certificate2 SelfSignedCert = TestCertificateUtils.CreateCertificate(nameof(MainTests) + " self signed");    // A self-signed cert
     private static readonly X509Certificate2Collection CertChain1 = TestCertificateUtils.CreateTestChain(nameof(MainTests) + " set 1");      // Two complete cert chains
-    private static readonly X509Certificate2Collection CertChain2 = TestCertificateUtils.CreateTestChain(nameof(MainTests) + " set 2");
-    private static readonly X509Certificate2 Root1Priv = CertChain1[0];                                                                                         // Roots from the chains       
-    private static readonly X509Certificate2 Root2Priv = CertChain2[0];
+    private static readonly X509Certificate2 Root1Priv = CertChain1[0];                                                                                         // Roots from the chains
     private static readonly X509Certificate2 Int1Priv = CertChain1[1];
     private static readonly X509Certificate2 Leaf1Priv = CertChain1[^1];                                                                                        // Leaf node certs
-    private static readonly X509Certificate2 Leaf2Priv = CertChain2[^1];
 
     // File paths to export them to
     private static readonly string PrivateKeyCertFileSelfSigned = Path.GetTempFileName() + "_SelfSigned.pfx";

--- a/CoseSignTool.Tests/ValidateCommandTests.cs
+++ b/CoseSignTool.Tests/ValidateCommandTests.cs
@@ -258,7 +258,8 @@ public class ValidateCommandTests
             coseStream,
             new FileInfo(Path.Combine(OutputPath!, "UnitTestPayload.json")),
             [root],
-            revocationMode);
+            revocationMode,
+            allowOutdated: true);
 
         result.Success.Should().BeTrue(result.ToString(true, true));
         result.ContentValidationType.Should().Be(ContentValidationType.Indirect);

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ The planned work is currently tracked only in an internal Microsoft ADO instance
 ## Requirements
 CoseSignTool runs on .NET 8. It depends on the libraries from this package and [Microsoft.Extensions.Configuration.CommandLine](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.CommandLine) from NuGet package version 7.0.0.
 
-The libraries depend on [System.Formats.Cbor](https://www.nuget.org/packages/System.Formats.Cbor/) version 7.0.0, [System.Security.Cryptography.Cose](https://www.nuget.org/packages/System.Security.Cryptography.Cose) version 7.0.0, and [System.Runtime.Caching](https://www.nuget.org/packages/System.Runtime.Caching) version 7.0.0 via NuGet package. Do not attempt to use later versions of System.Formats.Cbor or System.Security.Cryptography.Cose, as this breaks some of the fundamental data structures the libraries depend on.
-
 The API libraries all run on .NET Standard 2.0.
 
 ### Trademarks


### PR DESCRIPTION
Add CoseHashEnvelope support to signing library from https://datatracker.ietf.org/doc/draft-ietf-cose-hash-envelope/03/

This commit introduces a new signature version, `CoseHashEnvelope`, to replace the older `CoseHashV` format. Key changes include:

- Updated `CoseSign1MessageIndirectSignatureExtensionsTests` and `IndirectSignatureFactory` to support the new format.
- Refactored methods for creating indirect signatures to support `CoseHashEnvelope`.
- Added new overload that allow specification for which message format for the factory to create
- Updated existing method signatures to now use `CoseHashEnvelope` as the default format and `CoseHashV` is now the `useOldFormat=true` value.
- Enhanced `CoseSign1Message` with methods to check for `CoseHashEnvelope` presence and retrieve associated hash algorithms and content types.

These changes improve the functionality and flexibility of the COSE signing library while ensuring backward compatibility for creation and validation.