### PR TITLE
Allow beta version of Azure.Security.CodeTransparency

### DIFF
--- a/CoseSign1.Transparent.CTS/CoseSign1.Transparent.CTS.csproj
+++ b/CoseSign1.Transparent.CTS/CoseSign1.Transparent.CTS.csproj
@@ -46,7 +46,9 @@
 		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.3" />
+	  <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.3">
+		<NoWarn>NU5104</NoWarn>
+	  </PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\CoseSign1.Transparent\CoseSign1.Transparent.csproj" />


### PR DESCRIPTION
Allow beta version of Azure.Security.CodeTransparency in CoseSign1.Transparent.CTS by blocking the NU5104 warning to NuGet Pack can succeed.