### PR TITLE
feat: Add header extender support to IndirectSignatureFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,36 @@
 # Changelog
 
-## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
+## [v1.5.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.0-pre1) (2025-05-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.3.0-pre5)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.1...v1.5.0-pre1)
+
+## [v1.5.1](https://github.com/microsoft/CoseSignTool/tree/v1.5.1) (2025-05-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0-pre1...v1.5.1)
+
+**Merged pull requests:**
+
+- Allow beta version of Azure.Security.CodeTransparency [\#129](https://github.com/microsoft/CoseSignTool/pull/129) ([lemccomb](https://github.com/lemccomb))
+
+## [v1.4.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.4.0-pre1) (2025-04-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0...v1.4.0-pre1)
+
+## [v1.5.0](https://github.com/microsoft/CoseSignTool/tree/v1.5.0) (2025-04-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.5.0)
+
+**Merged pull requests:**
+
+- Added support for Transparency to CoseSign1 libraries to leverage services such as Azure Code Transparency Service [\#127](https://github.com/microsoft/CoseSignTool/pull/127) ([JeromySt](https://github.com/JeromySt))
 
 ## [v1.4.0](https://github.com/microsoft/CoseSignTool/tree/v1.4.0) (2025-03-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.4.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0)
+
+## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.3.0-pre5)
 
 **Merged pull requests:**
 
@@ -86,19 +110,19 @@
 
 ## [v1.2.8-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre3) (2024-10-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre1...v1.2.8-pre3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre2...v1.2.8-pre3)
 
 **Merged pull requests:**
 
 - Increase timeout for checking for empty streams [\#113](https://github.com/microsoft/CoseSignTool/pull/113) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre1) (2024-09-25)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre2...v1.2.8-pre1)
-
 ## [v1.2.8-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre2) (2024-09-25)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8...v1.2.8-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre1...v1.2.8-pre2)
+
+## [v1.2.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre1) (2024-09-25)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8...v1.2.8-pre1)
 
 **Merged pull requests:**
 
@@ -248,19 +272,19 @@
 
 ## [v1.2.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre2) (2024-03-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.1-pre2)
 
 **Merged pull requests:**
 
 - more granular error codes [\#86](https://github.com/microsoft/CoseSignTool/pull/86) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.2)
-
 ## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
+
+## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.2)
 
 **Merged pull requests:**
 
@@ -360,19 +384,19 @@
 
 ## [v1.1.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.3-pre1) (2024-01-26)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.3-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.3-pre1)
 
 **Merged pull requests:**
 
 - Adding Validation Option to Output Certificate Chain [\#73](https://github.com/microsoft/CoseSignTool/pull/73) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.3](https://github.com/microsoft/CoseSignTool/tree/v1.1.3) (2024-01-24)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.3)
-
 ## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.2-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.2-pre1)
+
+## [v1.1.3](https://github.com/microsoft/CoseSignTool/tree/v1.1.3) (2024-01-24)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.3)
 
 **Merged pull requests:**
 
@@ -453,7 +477,7 @@
 
 ## [v1.1.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre1) (2023-11-03)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v1.1.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0-pre1)
 
 **Merged pull requests:**
 
@@ -463,13 +487,13 @@
 - DetachedSignatureFactory accepts pre-hashed content as payload [\#53](https://github.com/microsoft/CoseSignTool/pull/53) ([elantiguamsft](https://github.com/elantiguamsft))
 - Add password support for certificate files [\#52](https://github.com/microsoft/CoseSignTool/pull/52) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0)
-
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v0.3.1-pre.10)
+
+## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v1.1.0)
 
 **Merged pull requests:**
 
@@ -479,13 +503,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
-
 ## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
+
+## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
 
 **Merged pull requests:**
 

--- a/CoseIndirectSignature/IndirectSignatureFactory.Bytes.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.Bytes.cs
@@ -17,13 +17,15 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public CoseSign1Message CreateIndirectSignature(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender coseHeaderExtender = null) =>
             CreateIndirectSignature(
                 payload: payload,
                 signingKeyProvider: signingKeyProvider,
@@ -33,7 +35,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                     ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                    : IndirectSignatureVersion.CoseHashEnvelope);
+                    : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -42,6 +45,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -49,7 +53,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureFromHash(
                 rawHash: rawHash,
                 signingKeyProvider: signingKeyProvider,
@@ -59,7 +64,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                     ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                    : IndirectSignatureVersion.CoseHashEnvelope);
+                    : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
     #endregion
     #region async old signature - backwards compatibility
     /// <summary>
@@ -69,13 +75,15 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public Task<CoseSign1Message> CreateIndirectSignatureAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureAsync(
                 payload: payload,
                 signingKeyProvider: signingKeyProvider,
@@ -85,7 +93,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                         ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                        : IndirectSignatureVersion.CoseHashEnvelope);
+                        : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -94,6 +103,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -101,7 +111,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureFromHashAsync(
                 rawHash: rawHash,
                 signingKeyProvider: signingKeyProvider,
@@ -111,7 +122,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                     ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                    : IndirectSignatureVersion.CoseHashEnvelope);
+                    : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
 
     #endregion
     #region sync new signature
@@ -122,19 +134,22 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public CoseSign1Message CreateIndirectSignature(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
                 returnBytes: false,
                 signingKeyProvider: signingKeyProvider,
                 contentType: contentType,
                 bytePayload: payload,
-                signatureVersion: signatureVersion);
+                signatureVersion: signatureVersion,
+                headerExtender: coseHeaderExtender);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -143,6 +158,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -150,14 +166,16 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
                 returnBytes: false,
                 signingKeyProvider: signingKeyProvider,
                 contentType: contentType,
                 bytePayload: rawHash,
                 payloadHashed: true,
-                signatureVersion: signatureVersion);
+                signatureVersion: signatureVersion,
+                headerExtender: coseHeaderExtender);
     #endregion
     #region async new signature
     /// <summary>
@@ -167,20 +185,23 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create..</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public Task<CoseSign1Message> CreateIndirectSignatureAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             Task.FromResult(
                 (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
                     returnBytes: false,
                     signingKeyProvider: signingKeyProvider,
                     contentType: contentType,
                     bytePayload: payload,
-                    signatureVersion: signatureVersion));
+                    signatureVersion: signatureVersion,
+                    headerExtender: coseHeaderExtender));
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -189,6 +210,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -196,7 +218,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             Task.FromResult(
                 (CoseSign1Message)CreateIndirectSignatureWithChecksInternal(
                     returnBytes: false,
@@ -204,7 +227,8 @@ public sealed partial class IndirectSignatureFactory
                     contentType: contentType,
                     bytePayload: rawHash,
                     payloadHashed: true,
-                    signatureVersion: signatureVersion));
+                    signatureVersion: signatureVersion,
+                    headerExtender: coseHeaderExtender));
     #endregion
     #endregion
 
@@ -217,13 +241,15 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public ReadOnlyMemory<byte> CreateIndirectSignatureBytes(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureBytes(
                 payload: payload,
                 signingKeyProvider: signingKeyProvider,
@@ -233,7 +259,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                         ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                        : IndirectSignatureVersion.CoseHashEnvelope);
+                        : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -242,6 +269,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -249,7 +277,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureBytesFromHash(
                 rawHash: rawHash,
                 signingKeyProvider: signingKeyProvider,
@@ -259,7 +288,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                         ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                        : IndirectSignatureVersion.CoseHashEnvelope);
+                        : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
     #endregion
     #region async old signature - backwards compatibility
     /// <summary>
@@ -269,13 +299,15 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureBytesAsync(
                 payload: payload,
                 signingKeyProvider: signingKeyProvider,
@@ -285,7 +317,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                         ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                        : IndirectSignatureVersion.CoseHashEnvelope);
+                        : IndirectSignatureVersion.CoseHashEnvelope,
+                coseHeaderExtender: coseHeaderExtender);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -294,6 +327,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="useOldFormat">True to use the older format - CoseHashV, False to use CoseHashEnvelope format (default).</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -301,7 +335,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        bool useOldFormat = false) =>
+        bool useOldFormat = false,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             CreateIndirectSignatureBytesFromHashAsync(
                     rawHash: rawHash,
                     signingKeyProvider: signingKeyProvider,
@@ -311,7 +346,8 @@ public sealed partial class IndirectSignatureFactory
 #pragma warning disable CS0618 // Type or member is obsolete
                             ? IndirectSignatureVersion.CoseHashV
 #pragma warning restore CS0618 // Type or member is obsolete
-                            : IndirectSignatureVersion.CoseHashEnvelope);
+                            : IndirectSignatureVersion.CoseHashEnvelope,
+                    coseHeaderExtender: coseHeaderExtender);
     #endregion
     #region sync new signature
     /// <summary>
@@ -321,19 +357,22 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public ReadOnlyMemory<byte> CreateIndirectSignatureBytes(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
                 returnBytes: true,
                 signingKeyProvider: signingKeyProvider,
                 contentType: contentType,
                 bytePayload: payload,
-                signatureVersion: signatureVersion);
+                signatureVersion: signatureVersion,
+                headerExtender: coseHeaderExtender);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -342,6 +381,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -349,14 +389,16 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
                 returnBytes: true,
                 signingKeyProvider: signingKeyProvider,
                 contentType: contentType,
                 bytePayload: rawHash,
                 payloadHashed: true,
-                signatureVersion: signatureVersion);
+                signatureVersion: signatureVersion,
+                headerExtender: coseHeaderExtender);
     #endregion
 
     #region async old signature - backwards compatibility
@@ -367,20 +409,23 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public Task<ReadOnlyMemory<byte>> CreateIndirectSignatureBytesAsync(
         ReadOnlyMemory<byte> payload,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             Task.FromResult(
                 (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
                     returnBytes: true,
                     signingKeyProvider: signingKeyProvider,
                     contentType: contentType,
                     bytePayload: payload,
-                    signatureVersion: signatureVersion));
+                    signatureVersion: signatureVersion,
+                    headerExtender: coseHeaderExtender));
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.
@@ -389,6 +434,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signingKeyProvider">The COSE signing key provider to be used for the signing operation within the <see cref="ICoseSign1MessageFactory"/>.</param>
     /// <param name="contentType">A media type string following https://datatracker.ietf.org/doc/html/rfc6838.</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>A Task which when completed returns a byte[] representation of a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentException">Hash size does not correspond to any known hash algorithms</exception>
@@ -396,7 +442,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte> rawHash,
         ICoseSigningKeyProvider signingKeyProvider,
         string contentType,
-        IndirectSignatureVersion signatureVersion) =>
+        IndirectSignatureVersion signatureVersion,
+        ICoseHeaderExtender? coseHeaderExtender = null) =>
             Task.FromResult(
                 (ReadOnlyMemory<byte>)CreateIndirectSignatureWithChecksInternal(
                     returnBytes: true,
@@ -404,7 +451,8 @@ public sealed partial class IndirectSignatureFactory
                     contentType: contentType,
                     bytePayload: rawHash,
                     payloadHashed: true,
-                    signatureVersion: signatureVersion));
+                    signatureVersion: signatureVersion,
+                    headerExtender: coseHeaderExtender));
     #endregion
     #endregion
 }

--- a/CoseIndirectSignature/IndirectSignatureFactory.CoseHashV.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.CoseHashV.cs
@@ -17,6 +17,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="streamPayload">If not null, then Stream API's on the CoseSign1MessageFactory are used.</param>
     /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
     /// <param name="payloadHashed">True if the payload represents the raw hash</param>
+    /// <param name="headerExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
@@ -27,7 +28,8 @@ public sealed partial class IndirectSignatureFactory
         string contentType,
         Stream? streamPayload = null,
         ReadOnlyMemory<byte>? bytePayload = null,
-        bool payloadHashed = false)
+        bool payloadHashed = false,
+        ICoseHeaderExtender? headerExtender = null)
     {
         CoseHashV hash;
         string extendedContentType = ExtendContentTypeCoseHashV(contentType);
@@ -61,13 +63,15 @@ public sealed partial class IndirectSignatureFactory
                     hash.Serialize(),
                     signingKeyProvider,
                     embedPayload: true,
-                    contentType: extendedContentType)
+                    contentType: extendedContentType,
+                    headerExtender: headerExtender)
                // return the CoseSign1Message object
                : InternalMessageFactory.CreateCoseSign1Message(
                     hash.Serialize(),
                     signingKeyProvider,
                     embedPayload: true,
-                    contentType: extendedContentType);
+                    contentType: extendedContentType,
+                    headerExtender: headerExtender);
     }
 
     /// <summary>

--- a/CoseIndirectSignature/IndirectSignatureFactory.Direct.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.Direct.cs
@@ -17,6 +17,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="streamPayload">If not null, then Stream API's on the CoseSign1MessageFactory are used.</param>
     /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
     /// <param name="payloadHashed">True if the payload represents the raw hash</param>
+    /// <param name="headerExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
@@ -27,7 +28,8 @@ public sealed partial class IndirectSignatureFactory
         string contentType,
         Stream? streamPayload = null,
         ReadOnlyMemory<byte>? bytePayload = null,
-        bool payloadHashed = false)
+        bool payloadHashed = false,
+        ICoseHeaderExtender? headerExtender = null)
     {
         ReadOnlyMemory<byte> hash;
         string extendedContentType;
@@ -59,12 +61,14 @@ public sealed partial class IndirectSignatureFactory
                     hash,
                     signingKeyProvider,
                     embedPayload: true,
-                    contentType: extendedContentType)
+                    contentType: extendedContentType,
+                    headerExtender: headerExtender)
                : InternalMessageFactory.CreateCoseSign1Message(
                     hash,
                     signingKeyProvider,
                     embedPayload: true,
-                    contentType: extendedContentType);
+                    contentType: extendedContentType,
+                    headerExtender: headerExtender);
     }
 
     /// <summary>

--- a/CoseIndirectSignature/IndirectSignatureFactory.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.cs
@@ -108,6 +108,7 @@ public sealed partial class IndirectSignatureFactory : IDisposable
     /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
     /// <param name="payloadHashed">True if the payload represents the raw hash</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
+    /// <param name="headerExtender">An optional <see cref="ICoseHeaderExtender"/> to extend the protected headers of the CoseSign1Message.</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
@@ -119,7 +120,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
         IndirectSignatureVersion signatureVersion,
         Stream? streamPayload = null,
         ReadOnlyMemory<byte>? bytePayload = null,
-        bool payloadHashed = false)
+        bool payloadHashed = false,
+        ICoseHeaderExtender? headerExtender = null)
     {
         if (string.IsNullOrWhiteSpace(contentType))
         {
@@ -143,7 +145,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
                             contentType,
                             streamPayload,
                             bytePayload,
-                            payloadHashed);
+                            payloadHashed,
+                            headerExtender);
 #pragma warning disable CS0618 // Type or member is obsolete
             case IndirectSignatureVersion.CoseHashV:
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -153,7 +156,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
                             contentType,
                             streamPayload,
                             bytePayload,
-                            payloadHashed);
+                            payloadHashed,
+                            headerExtender);
             case IndirectSignatureVersion.CoseHashEnvelope:
                 return CreateIndirectSignatureWithChecksInternalCoseHashEnvelopeFormat(
                             returnBytes,
@@ -161,7 +165,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
                             contentType,
                             streamPayload,
                             bytePayload,
-                            payloadHashed);
+                            payloadHashed,
+                            headerExtender);
             default:
                 throw new ArgumentOutOfRangeException(nameof(signatureVersion), "Unknown signature version");
         }

--- a/CoseSign1.Tests/ChainedCoseHeaderExtenderTests.cs
+++ b/CoseSign1.Tests/ChainedCoseHeaderExtenderTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseSign1.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ChainedCoseHeaderExtender"/>.
+/// </summary>
+public class ChainedCoseHeaderExtenderTests
+{
+    /// <summary>
+    /// Dummy implementation of <see cref="ICoseHeaderExtender"/> for testing chaining behavior.
+    /// </summary>
+    private class DummyExtender : ICoseHeaderExtender
+    {
+        private readonly Func<CoseHeaderMap, CoseHeaderMap> Protected;
+        private readonly Func<CoseHeaderMap?, CoseHeaderMap> Unprotected;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DummyExtender"/> class.
+        /// </summary>
+        /// <param name="protectedFunc">Delegate to handle <see cref="ExtendProtectedHeaders"/>.</param>
+        /// <param name="unprotectedFunc">Delegate to handle <see cref="ExtendUnProtectedHeaders"/>.</param>
+        public DummyExtender(Func<CoseHeaderMap, CoseHeaderMap> protectedFunc, Func<CoseHeaderMap?, CoseHeaderMap> unprotectedFunc)
+        {
+            Protected = protectedFunc;
+            Unprotected = unprotectedFunc;
+        }
+        /// <inheritdoc/>
+        public CoseHeaderMap ExtendProtectedHeaders(CoseHeaderMap protectedHeaders) => Protected(protectedHeaders);
+        /// <inheritdoc/>
+        public CoseHeaderMap ExtendUnProtectedHeaders(CoseHeaderMap? unProtectedHeaders) => Unprotected(unProtectedHeaders);
+    }
+
+    [Test]
+    public void Constructor_ThrowsOnNullEnumerable()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ChainedCoseHeaderExtender(null!));
+    }
+
+    [Test]
+    public void Constructor_ThrowsOnNullElement()
+    {
+        var extenders = new ICoseHeaderExtender[] { new DummyExtender(h => h, h => h!), null! };
+        Assert.Throws<ArgumentException>(() => new ChainedCoseHeaderExtender(extenders));
+    }
+
+    [Test]
+    public void ExtendProtectedHeaders_ThrowsOnNullInput()
+    {
+        var chain = new ChainedCoseHeaderExtender(new[] { new DummyExtender(h => h, h => h) });
+        Assert.Throws<ArgumentNullException>(() => chain.ExtendProtectedHeaders(null));
+    }
+
+    [Test]
+    public void ExtendProtectedHeaders_ThrowsIfAnyExtenderReturnsNull()
+    {
+        var extenders = new ICoseHeaderExtender[] {
+            new DummyExtender(h => h, h => h),
+            new DummyExtender(h => null, h => h)
+        };
+        var chain = new ChainedCoseHeaderExtender(extenders);
+        Assert.Throws<InvalidOperationException>(() => chain.ExtendProtectedHeaders(new CoseHeaderMap()));
+    }
+
+    [Test]
+    public void ExtendUnProtectedHeaders_ThrowsIfAnyExtenderReturnsNull()
+    {
+        var extenders = new ICoseHeaderExtender[] {
+            new DummyExtender(h => h, h => h),
+            new DummyExtender(h => h, h => null)
+        };
+        var chain = new ChainedCoseHeaderExtender(extenders);
+        Assert.Throws<InvalidOperationException>(() => chain.ExtendUnProtectedHeaders(new CoseHeaderMap()));
+    }
+
+    [Test]
+    public void ExtendProtectedHeaders_ChainsCorrectly()
+    {
+        var chain = new ChainedCoseHeaderExtender(new ICoseHeaderExtender[] {
+            new DummyExtender(h => { h[new CoseHeaderLabel("a")] = CoseHeaderValue.FromInt32(1); return h; }, h => h!),
+            new DummyExtender(h => { h[new CoseHeaderLabel("b")] = CoseHeaderValue.FromInt32(2); return h; }, h => h!)
+        });
+        var map = new CoseHeaderMap();
+        var result = chain.ExtendProtectedHeaders(map);
+        result[new CoseHeaderLabel("a")].GetValueAsInt32().Should().Be(1);
+        result[new CoseHeaderLabel("b")].GetValueAsInt32().Should().Be(2);
+    }
+
+    [Test]
+    public void ExtendUnProtectedHeaders_ChainsCorrectly()
+    {
+        var chain = new ChainedCoseHeaderExtender(new ICoseHeaderExtender[] {
+            new DummyExtender(h => h, h => { h![new CoseHeaderLabel("x")] = CoseHeaderValue.FromInt32(10); return h; }),
+            new DummyExtender(h => h, h => { h![new CoseHeaderLabel("y")] = CoseHeaderValue.FromInt32(20); return h; })
+        });
+        var map = new CoseHeaderMap();
+        var result = chain.ExtendUnProtectedHeaders(map);
+        result[new CoseHeaderLabel("x")].GetValueAsInt32().Should().Be(10);
+        result[new CoseHeaderLabel("y")].GetValueAsInt32().Should().Be(20);
+    }
+}
+

--- a/CoseSign1/ChainedCoseHeaderExtender.cs
+++ b/CoseSign1/ChainedCoseHeaderExtender.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CoseSign1;
+
+/// <summary>
+/// Chains multiple <see cref="ICoseHeaderExtender"/> instances and applies them in order to protected and unprotected COSE header maps.
+/// </summary>
+/// <remarks>
+/// This class allows composition of multiple header extenders, executing each in sequence. Each extender's output is passed as input to the next.
+/// If any extender returns <c>null</c>, an <see cref="InvalidOperationException"/> is thrown. The input list and all elements must be non-null.
+/// </remarks>
+public sealed class ChainedCoseHeaderExtender : ICoseHeaderExtender
+{
+    private readonly IReadOnlyList<ICoseHeaderExtender> Extenders;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChainedCoseHeaderExtender"/> class.
+    /// </summary>
+    /// <param name="extenders">The sequence of <see cref="ICoseHeaderExtender"/> instances to chain. Must not be null and must not contain null elements.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="extenders"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if any element in <paramref name="extenders"/> is null.</exception>
+    public ChainedCoseHeaderExtender(IEnumerable<ICoseHeaderExtender> extenders)
+    {
+        if (extenders == null)
+        {
+            throw new ArgumentNullException(nameof(extenders));
+        }
+
+        if (extenders.Any(e => e == null))
+        {
+            throw new ArgumentException("One or more extenders are null.", nameof(extenders));
+        }
+
+        Extenders = extenders.ToList().AsReadOnly();
+    }
+
+    /// <summary>
+    /// Applies all chained extenders to the provided protected headers in order.
+    /// </summary>
+    /// <param name="protectedHeaders">The initial <see cref="CoseHeaderMap"/> to extend. Must not be null.</param>
+    /// <returns>The extended <see cref="CoseHeaderMap"/> after all extenders have been applied.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="protectedHeaders"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if any extender returns null.</exception>
+    public CoseHeaderMap ExtendProtectedHeaders(CoseHeaderMap protectedHeaders)
+    {
+        if (protectedHeaders == null)
+        {
+            throw new ArgumentNullException(nameof(protectedHeaders));
+        }
+
+        CoseHeaderMap result = protectedHeaders;
+        foreach (var extender in Extenders)
+        {
+            result = extender.ExtendProtectedHeaders(result);
+            if (result == null)
+            {
+                throw new InvalidOperationException($"Extender {extender.GetType().Name} returned null from ExtendProtectedHeaders.");
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Applies all chained extenders to the provided unprotected headers in order.
+    /// </summary>
+    /// <param name="unProtectedHeaders">The initial <see cref="CoseHeaderMap"/> to extend. May be null.</param>
+    /// <returns>The extended <see cref="CoseHeaderMap"/> after all extenders have been applied.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if any extender returns null.</exception>
+    public CoseHeaderMap ExtendUnProtectedHeaders(CoseHeaderMap? unProtectedHeaders)
+    {
+        CoseHeaderMap? result = unProtectedHeaders;
+        foreach (var extender in Extenders)
+        {
+            result = extender.ExtendUnProtectedHeaders(result);
+            if (result == null)
+            {
+                throw new InvalidOperationException($"Extender {extender.GetType().Name} returned null from ExtendUnProtectedHeaders.");
+            }
+        }
+        return result!;
+    }
+}


### PR DESCRIPTION
- Updated IndirectSignatureFactory methods to accept an optional ICoseHeaderExtender parameter for adding custom headers to COSE messages.
- Introduced ChainedCoseHeaderExtender to allow chaining multiple header extenders.
- Added unit tests for ChainedCoseHeaderExtender to ensure correct behavior and error handling.