### PR TITLE
BugFix: Normalize CommonName Checks

### DIFF
--- a/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
+++ b/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
@@ -29,15 +29,25 @@ public class X509CommonNameValidatorTests
     [Test]
     public void ValidateCommonName()
     {
-        X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate();
-        X509CommonNameValidator.ValidateCommonName(selfSignedRoot, selfSignedRoot.SubjectName.Name);
+        string subjectName = "Test Certificate, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
+        X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate(subjectName);
+        X509CommonNameValidator.ValidateCommonName(selfSignedRoot, $"CN={subjectName}");
     }
 
     [Test]
-    public void ValidateCommonNameFail()
+    public void ValidateBadlyFormedCommonNameFail()
     {
         X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate();
-        Assert.Throws<CoseValidationException>(() => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "epic fail"));
+        Exception e = Assert.Throws<CoseValidationException>(() => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "epic fail"));
+        e.Message.Should().Contain("Invalid common name format");
+    }
+
+    [Test]
+    public void ValidateIncorrectCommonNameFail()
+    {
+        X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate();
+        Exception e = Assert.Throws<CoseValidationException>(() => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "CN=epic fail"));
+        e.Message.Should().Contain("does not match required name");
     }
 
     /// <summary>

--- a/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
+++ b/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
@@ -43,7 +43,7 @@ public class X509CommonNameValidatorTests
     }
 
     /// <summary>
-    /// Testing Constructors Success
+    /// Testing Constructors Success 
     /// </summary>
     /// <param name="inputCase"></param>
     [Test,

--- a/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
+++ b/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
@@ -31,23 +31,15 @@ public class X509CommonNameValidatorTests
     {
         string subjectName = "Test Certificate, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
         X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate(subjectName);
-        X509CommonNameValidator.ValidateCommonName(selfSignedRoot, $"CN={subjectName}");
+        X509CommonNameValidator.ValidateCommonName(selfSignedRoot, subjectName);
     }
 
     [Test]
-    public void ValidateBadlyFormedCommonNameFail()
+    public void ValidateCommonNameFail()
     {
         X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate();
         Exception e = Assert.Throws<CoseValidationException>(() => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "epic fail"));
-        e.Message.Should().Contain("Invalid common name format");
-    }
-
-    [Test]
-    public void ValidateIncorrectCommonNameFail()
-    {
-        X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate();
-        Exception e = Assert.Throws<CoseValidationException>(() => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "CN=epic fail"));
-        e.Message.Should().Contain("does not match required name");
+        e.Message.Should().Contain("does not match");
     }
 
     /// <summary>

--- a/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
+++ b/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
@@ -63,11 +63,21 @@ public class X509CommonNameValidator : X509Certificate2MessageValidator
     {
         if (commonName is not null)
         {
-            string signingCertSubjectName = cert.SubjectName.Format(multiLine: false);
+            string signingCertSubjectName = cert.SubjectName.Format(multiLine: true);
+            string requiredCommonName;
 
-            if (!commonName.Equals(signingCertSubjectName, StringComparison.Ordinal))
+            try
             {
-                throw new CoseValidationException($"Signing certificate common name [{signingCertSubjectName}] does not match required name [{commonName}]");
+                requiredCommonName = new X500DistinguishedName(commonName).Format(multiLine: true);
+            }
+            catch (CryptographicException e)
+            {
+                throw new CoseValidationException($"Invalid common name format: {commonName}. Please provide a valid {nameof(X500DistinguishedName)}.", e);
+            }
+
+            if (!requiredCommonName.Equals(signingCertSubjectName, StringComparison.Ordinal))
+            {
+                throw new CoseValidationException($"Signing certificate common name [{signingCertSubjectName}] does not match required name [{requiredCommonName}]");
             }
         }
     }

--- a/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
+++ b/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
@@ -63,21 +63,11 @@ public class X509CommonNameValidator : X509Certificate2MessageValidator
     {
         if (commonName is not null)
         {
-            string signingCertSubjectName = cert.SubjectName.Format(multiLine: true);
-            string requiredCommonName;
+            string signerCommonName = cert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
 
-            try
+            if (!commonName.Contains(signerCommonName))
             {
-                requiredCommonName = new X500DistinguishedName(commonName).Format(multiLine: true);
-            }
-            catch (CryptographicException e)
-            {
-                throw new CoseValidationException($"Invalid common name format: {commonName}. Please provide a valid {nameof(X500DistinguishedName)}.", e);
-            }
-
-            if (!requiredCommonName.Equals(signingCertSubjectName, StringComparison.Ordinal))
-            {
-                throw new CoseValidationException($"Signing certificate common name [{signingCertSubjectName}] does not match required name [{requiredCommonName}]");
+                throw new CoseValidationException($"Signing certificate common name [{signerCommonName}] does not match [{commonName}]");
             }
         }
     }


### PR DESCRIPTION
This pull request fixes the `X509CommonNameValidator` functionality. Previously, the validator compared the entire subject of the signer, formatted as a an `X500DistinguishedName` against the input. Like SignTool.exe's -n parameter, the validator now checks to make sure the common name string includes the provided input.