### PR TITLE
Enhance PFX certificate handling in SignCommand and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,36 @@
 # Changelog
 
-## [v1.5.3-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.5.3-pre2) (2025-06-05)
+## [Unreleased](https://github.com/microsoft/CoseSignTool/tree/HEAD)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.4...v1.5.3-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.6...HEAD)
+
+**Merged pull requests:**
+
+- Migrate from VSTest to MTP [\#124](https://github.com/microsoft/CoseSignTool/pull/124) ([Youssef1313](https://github.com/Youssef1313))
+
+## [v1.5.6](https://github.com/microsoft/CoseSignTool/tree/v1.5.6) (2025-07-15)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v.1.5.5...v1.5.6)
+
+## [v.1.5.5](https://github.com/microsoft/CoseSignTool/tree/v.1.5.5) (2025-07-15)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.4-pre1...v.1.5.5)
+
+## [v1.5.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.4-pre1) (2025-07-15)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.4...v1.5.4-pre1)
+
+**Merged pull requests:**
+
+- Add KeyChain property to ICoseSigningKeyProvider and implement related concrete implementations and tests [\#136](https://github.com/microsoft/CoseSignTool/pull/136) ([JeromySt](https://github.com/JeromySt))
 
 ## [v1.5.4](https://github.com/microsoft/CoseSignTool/tree/v1.5.4) (2025-06-05)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.3-pre1...v1.5.4)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.3-pre2...v1.5.4)
+
+## [v1.5.3-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.5.3-pre2) (2025-06-05)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.3-pre1...v1.5.3-pre2)
 
 **Merged pull requests:**
 
@@ -14,19 +38,19 @@
 
 ## [v1.5.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.3-pre1) (2025-06-05)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.3...v1.5.3-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.2-pre1...v1.5.3-pre1)
 
 **Merged pull requests:**
 
 - Add unit tests for CoseSign1MessageExtensions and enhance Certificate… [\#133](https://github.com/microsoft/CoseSignTool/pull/133) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.5.3](https://github.com/microsoft/CoseSignTool/tree/v1.5.3) (2025-05-30)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.2-pre1...v1.5.3)
-
 ## [v1.5.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.2-pre1) (2025-05-30)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.2...v1.5.2-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.3...v1.5.2-pre1)
+
+## [v1.5.3](https://github.com/microsoft/CoseSignTool/tree/v1.5.3) (2025-05-30)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.2...v1.5.3)
 
 **Merged pull requests:**
 
@@ -50,31 +74,31 @@
 
 ## [v1.5.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.0-pre1) (2025-05-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0...v1.5.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0-pre1...v1.5.0-pre1)
 
 **Merged pull requests:**
 
 - Allow beta version of Azure.Security.CodeTransparency [\#129](https://github.com/microsoft/CoseSignTool/pull/129) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.5.0](https://github.com/microsoft/CoseSignTool/tree/v1.5.0) (2025-04-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0-pre1...v1.5.0)
-
 ## [v1.4.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.4.0-pre1) (2025-04-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0...v1.4.0-pre1)
+
+## [v1.5.0](https://github.com/microsoft/CoseSignTool/tree/v1.5.0) (2025-04-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.5.0)
 
 **Merged pull requests:**
 
 - Added support for Transparency to CoseSign1 libraries to leverage services such as Azure Code Transparency Service [\#127](https://github.com/microsoft/CoseSignTool/pull/127) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.3.0-pre5)
-
 ## [v1.4.0](https://github.com/microsoft/CoseSignTool/tree/v1.4.0) (2025-03-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.4.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0)
+
+## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.3.0-pre5)
 
 **Merged pull requests:**
 
@@ -244,19 +268,19 @@
 
 ## [v1.2.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.4-pre1) (2024-07-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4...v1.2.4-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre7...v1.2.4-pre1)
 
 **Merged pull requests:**
 
 - User/lemccomb/fileread [\#94](https://github.com/microsoft/CoseSignTool/pull/94) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.4](https://github.com/microsoft/CoseSignTool/tree/v1.2.4) (2024-06-14)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre7...v1.2.4)
-
 ## [v1.2.3-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.2.3-pre7) (2024-06-14)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre6...v1.2.3-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4...v1.2.3-pre7)
+
+## [v1.2.4](https://github.com/microsoft/CoseSignTool/tree/v1.2.4) (2024-06-14)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.3-pre6...v1.2.4)
 
 **Merged pull requests:**
 
@@ -328,19 +352,19 @@
 
 ## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.1-pre1)
 
 **Merged pull requests:**
 
 - Revert "Add .exe to CoseSignTool NuGet" [\#83](https://github.com/microsoft/CoseSignTool/pull/83) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.2.1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1) (2024-03-07)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0-pre1...v1.2.1)
-
 ## [v1.2.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.0-pre1) (2024-03-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.exeTest...v1.2.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.0-pre1)
+
+## [v1.2.1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1) (2024-03-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.exeTest...v1.2.1)
 
 **Merged pull requests:**
 
@@ -348,15 +372,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
-
-## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
 
 ## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7-pre3...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+
+## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7-pre3...v1.2.0)
 
 **Merged pull requests:**
 
@@ -521,7 +545,7 @@
 
 ## [v1.1.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre1) (2023-11-03)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v1.1.0-pre1)
 
 **Merged pull requests:**
 
@@ -531,13 +555,13 @@
 - DetachedSignatureFactory accepts pre-hashed content as payload [\#53](https://github.com/microsoft/CoseSignTool/pull/53) ([elantiguamsft](https://github.com/elantiguamsft))
 - Add password support for certificate files [\#52](https://github.com/microsoft/CoseSignTool/pull/52) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v0.3.1-pre.10)
-
 ## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v1.1.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0)
+
+## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -547,13 +571,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
-
 ## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
+
+## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
 
 **Merged pull requests:**
 

--- a/CoseSignTool.Tests/SignCommandTests.cs
+++ b/CoseSignTool.Tests/SignCommandTests.cs
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.Cose;
+using CoseSign1.Certificates.Exceptions;
+using CoseSign1.Certificates.Extensions;
+
 namespace CoseSignTool.Tests;
 
 [TestClass]
@@ -70,5 +76,302 @@ public class SignCommandTests
         cmd1.IntHeaders.Count.Should().Be(2, "When both input file and command line headers are supplied, the command line headers are not ignored");
 
         cmd1.IntHeaders.ForEach(h => h.IsProtected.Should().Be(true, "Protected flag is not set to default value of false when unsupplied"));
+    }
+
+    [TestMethod]
+    public void SignWithPfxCertificateChain_ExtractsAllCertificatesFromPfx()
+    {
+        // Arrange - Create a PFX file containing the full certificate chain
+        string pfxChainFile = Path.GetTempFileName() + "_Chain.pfx";
+        try
+        {
+            // Export the entire chain to a single PFX file
+            X509Certificate2Collection chainCollection = new();
+            chainCollection.AddRange(CertChain1);
+            
+            byte[] pfxBytes = chainCollection.Export(X509ContentType.Pkcs12);
+            File.WriteAllBytes(pfxChainFile, pfxBytes);
+
+            string payloadFile = FileSystemUtils.GeneratePayloadFile();
+
+            // Act - Sign using the PFX with full chain
+            string[] args = ["sign", "/p", payloadFile, "/pfx", pfxChainFile, "/ep"];
+            var provider = CoseCommand.LoadCommandLineArgs(args, SignCommand.Options, out string? badArg)!;
+            badArg.Should().BeNull("badArg should be null.");
+
+            var cmd = new SignCommand();
+            cmd.ApplyOptions(provider);
+
+            // Verify LoadCert extracts the signing certificate and additional roots
+            var (cert, additionalRoots) = cmd.LoadCert();
+
+            // Assert
+            cert.Should().NotBeNull("Signing certificate should be found");
+            cert.HasPrivateKey.Should().BeTrue("Signing certificate should have private key");
+            
+            additionalRoots.Should().NotBeNull("Additional roots should be extracted from PFX");
+            additionalRoots!.Count.Should().BeGreaterThan(0, "Should have additional certificates from the chain");
+            
+            // Verify that the additional roots contain the other certificates from the chain
+            // (excluding the signing certificate itself)
+            var expectedAdditionalCerts = CertChain1.Cast<X509Certificate2>()
+                .Where(c => !c.Equals(cert))
+                .ToList();
+            
+            additionalRoots.Count.Should().Be(expectedAdditionalCerts.Count, 
+                "Should extract all non-signing certificates as additional roots");
+
+            // Verify the sign operation completes successfully
+            ExitCode result = cmd.Run();
+            result.Should().Be(ExitCode.Success, "Sign operation should succeed");
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(pfxChainFile))
+            {
+                File.Delete(pfxChainFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SignWithPfxCertificateChain_UsesAdditionalRootsForChainBuilding()
+    {
+        // Arrange - Create a PFX file containing the full certificate chain
+        string pfxChainFile = Path.GetTempFileName() + "_ChainForValidation.pfx";
+        try
+        {
+            // Export the entire chain to a single PFX file
+            X509Certificate2Collection chainCollection = new();
+            chainCollection.AddRange(CertChain1);
+            
+            byte[] pfxBytes = chainCollection.Export(X509ContentType.Pkcs12);
+            File.WriteAllBytes(pfxChainFile, pfxBytes);
+
+            string payloadFile = FileSystemUtils.GeneratePayloadFile();
+            string signatureFile = Path.GetTempFileName() + ".cose";
+
+            try
+            {
+                // Act - Sign using the PFX with full chain
+                string[] args = ["sign", "/p", payloadFile, "/pfx", pfxChainFile, "/sf", signatureFile];
+                var provider = CoseCommand.LoadCommandLineArgs(args, SignCommand.Options, out string? badArg)!;
+                badArg.Should().BeNull("badArg should be null.");
+
+                var cmd = new SignCommand();
+                cmd.ApplyOptions(provider);
+
+                ExitCode result = cmd.Run();
+                result.Should().Be(ExitCode.Success, "Sign operation should succeed with certificate chain");
+
+                // Assert - Verify that the signature file was created and contains valid COSE signature
+                File.Exists(signatureFile).Should().BeTrue("Signature file should be created");
+                
+                byte[] signatureBytes = File.ReadAllBytes(signatureFile);
+                signatureBytes.Length.Should().BeGreaterThan(0, "Signature file should not be empty");
+                
+                // Verify we can read the COSE signature (basic validation)
+                var coseMessage = CoseSign1Message.DecodeSign1(signatureBytes);
+                coseMessage.Should().NotBeNull("Should be able to decode the COSE signature");
+
+                // Extract and validate the certificate chain from the COSE message
+                bool foundSigningCert = coseMessage.TryGetSigningCertificate(out X509Certificate2? extractedSigningCert);
+                foundSigningCert.Should().BeTrue("Should be able to extract signing certificate from COSE message");
+                extractedSigningCert.Should().NotBeNull("Extracted signing certificate should not be null");
+
+                bool foundCertChain = coseMessage.TryGetCertificateChain(out List<X509Certificate2>? extractedCertChain);
+                foundCertChain.Should().BeTrue("Should be able to extract certificate chain from COSE message");
+                extractedCertChain.Should().NotBeNull("Extracted certificate chain should not be null");
+                extractedCertChain!.Count.Should().Be(3, "Certificate chain should contain all 3 certificates (root, intermediate, leaf)");
+
+                // Verify that the extracted signing certificate matches one from our test chain
+                var expectedSigningCert = CertChain1.Cast<X509Certificate2>().First(c => c.HasPrivateKey);
+                extractedSigningCert!.Thumbprint.Should().Be(expectedSigningCert.Thumbprint, 
+                    "Extracted signing certificate should match the expected signing certificate");
+
+                // Verify the certificate chain contains all expected certificates
+                var expectedCertificates = CertChain1.Cast<X509Certificate2>().ToList();
+                foreach (var expectedCert in expectedCertificates)
+                {
+                    extractedCertChain.Any(c => c.Thumbprint == expectedCert.Thumbprint).Should().BeTrue(
+                        $"Certificate chain should contain certificate with subject '{expectedCert.Subject}'");
+                }
+            }
+            finally
+            {
+                if (File.Exists(signatureFile))
+                {
+                    File.Delete(signatureFile);
+                }
+            }
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(pfxChainFile))
+            {
+                File.Delete(pfxChainFile);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void LoadCertFromPfxWithThumbprintFindsSpecificCertificate()
+    {
+        // Create a PFX file containing a full certificate chain
+        string pfxFileWithChain = Path.GetTempFileName() + "_chain.pfx";
+        
+        try
+        {
+            // Export the full certificate chain to a PFX file
+            X509Certificate2Collection chainCollection = new();
+            chainCollection.AddRange(CertChain1);
+            byte[] pfxBytes = chainCollection.Export(X509ContentType.Pkcs12, CertPassword);
+            File.WriteAllBytes(pfxFileWithChain, pfxBytes);
+
+            // Create a SignCommand and configure it to use the PFX with a specific thumbprint
+            var cmd = new SignCommand
+            {
+                PfxCertificate = pfxFileWithChain,
+                Password = CertPassword,
+                Thumbprint = Leaf1Priv.Thumbprint // Specify the leaf certificate's thumbprint
+            };
+
+            // Test LoadCert method
+            var (signingCert, additionalRoots) = cmd.LoadCert();
+            
+            // Verify the signing certificate matches the specified thumbprint
+            signingCert.Should().NotBeNull("Signing certificate should be found");
+            signingCert.Thumbprint.Should().Be(Leaf1Priv.Thumbprint, "Should find the certificate with the specified thumbprint");
+            signingCert.HasPrivateKey.Should().BeTrue("Signing certificate should have private key");
+            
+            // Verify additional roots contain the other certificates
+            additionalRoots.Should().NotBeNull("Additional roots should be extracted");
+            additionalRoots.Should().HaveCount(2, "Should have root and intermediate certificates as additional roots");
+            additionalRoots.Should().NotContain(signingCert, "Additional roots should not contain the signing certificate");
+        }
+        finally
+        {
+            if (File.Exists(pfxFileWithChain))
+            {
+                File.Delete(pfxFileWithChain);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void LoadCertFromPfxWithInvalidThumbprintThrowsException()
+    {
+        // Create a PFX file containing a full certificate chain
+        string pfxFileWithChain = Path.GetTempFileName() + "_chain.pfx";
+        
+        try
+        {
+            // Export the full certificate chain to a PFX file
+            X509Certificate2Collection chainCollection = new();
+            chainCollection.AddRange(CertChain1);
+            byte[] pfxBytes = chainCollection.Export(X509ContentType.Pkcs12, CertPassword);
+            File.WriteAllBytes(pfxFileWithChain, pfxBytes);
+
+            // Create a SignCommand with an invalid thumbprint
+            var cmd = new SignCommand
+            {
+                PfxCertificate = pfxFileWithChain,
+                Password = CertPassword,
+                Thumbprint = "INVALIDTHUMBPRINT1234567890ABCDEF12345678" // Non-existent thumbprint
+            };
+
+            // Test LoadCert method should throw exception
+            Action loadCertAction = () => cmd.LoadCert();
+            loadCertAction.Should().Throw<CoseSign1CertificateException>()
+                .WithMessage("*No certificate with private key and thumbprint 'INVALIDTHUMBPRINT1234567890ABCDEF12345678' found in PFX file*");
+        }
+        finally
+        {
+            if (File.Exists(pfxFileWithChain))
+            {
+                File.Delete(pfxFileWithChain);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SignWithPfxAndThumbprintSucceeds()
+    {
+        // Create a PFX file containing a full certificate chain
+        string pfxFileWithChain = Path.GetTempFileName() + "_chain.pfx";
+        string payloadFile = FileSystemUtils.GeneratePayloadFile();
+        
+        try
+        {
+            // Export the full certificate chain to a PFX file
+            X509Certificate2Collection chainCollection = new();
+            chainCollection.AddRange(CertChain1);
+            byte[] pfxBytes = chainCollection.Export(X509ContentType.Pkcs12, CertPassword);
+            File.WriteAllBytes(pfxFileWithChain, pfxBytes);
+
+            // Sign using the PFX with a specific thumbprint
+            string[] args = ["sign", "/p", payloadFile, "/pfx", pfxFileWithChain, "/pw", CertPassword, "/th", Leaf1Priv.Thumbprint, "/ep"];
+            var provider = CoseCommand.LoadCommandLineArgs(args, SignCommand.Options, out string? badArg)!;
+            badArg.Should().BeNull("badArg should be null.");
+
+            var cmd = new SignCommand();
+            cmd.ApplyOptions(provider);
+            ExitCode result = cmd.Run();
+
+            // Verify signing succeeded
+            result.Should().Be(ExitCode.Success, "Signing with PFX and specific thumbprint should succeed");
+
+            // Verify that the correct certificate was used
+            var (signingCert, additionalRoots) = cmd.LoadCert();
+            signingCert.Thumbprint.Should().Be(Leaf1Priv.Thumbprint, "Should use the certificate with the specified thumbprint");
+            additionalRoots.Should().HaveCount(2, "Should extract other certificates as additional roots");
+
+            // Verify that a signature file was created and extract certificates from it
+            string? signatureFilePath = cmd.SignatureFile?.FullName;
+            signatureFilePath.Should().NotBeNull("Signature file path should be set");
+            File.Exists(signatureFilePath!).Should().BeTrue("Signature file should exist");
+
+            byte[] signatureBytes = File.ReadAllBytes(signatureFilePath);
+            var coseMessage = CoseSign1Message.DecodeSign1(signatureBytes);
+
+            // Extract and validate certificates from the COSE message
+            bool foundSigningCert = coseMessage.TryGetSigningCertificate(out X509Certificate2? extractedSigningCert);
+            foundSigningCert.Should().BeTrue("Should extract signing certificate from COSE message");
+            extractedSigningCert!.Thumbprint.Should().Be(Leaf1Priv.Thumbprint, 
+                "Extracted signing certificate should match the specified thumbprint");
+
+            bool foundCertChain = coseMessage.TryGetCertificateChain(out List<X509Certificate2>? extractedCertChain);
+            foundCertChain.Should().BeTrue("Should extract certificate chain from COSE message");
+            extractedCertChain.Should().NotBeNull("Certificate chain should not be null");
+            extractedCertChain!.Count.Should().Be(3, "Should have full certificate chain embedded");
+
+            // Verify that the chain contains the expected certificates
+            var rootCert = extractedCertChain.FirstOrDefault(c => c.Thumbprint == Root1Priv.Thumbprint);
+            var intermediateCert = extractedCertChain.FirstOrDefault(c => c.Thumbprint == Int1Priv.Thumbprint);
+            var leafCert = extractedCertChain.FirstOrDefault(c => c.Thumbprint == Leaf1Priv.Thumbprint);
+
+            rootCert.Should().NotBeNull("Root certificate should be in the chain");
+            intermediateCert.Should().NotBeNull("Intermediate certificate should be in the chain");
+            leafCert.Should().NotBeNull("Leaf certificate should be in the chain");
+
+            // Clean up the signature file
+            if (File.Exists(signatureFilePath))
+            {
+                File.Delete(signatureFilePath);
+            }
+        }
+        finally
+        {
+            if (File.Exists(pfxFileWithChain))
+            {
+                File.Delete(pfxFileWithChain);
+            }
+            if (File.Exists(payloadFile))
+            {
+                File.Delete(payloadFile);
+            }
+        }
     }
 }

--- a/docs/CoseHandler.md
+++ b/docs/CoseHandler.md
@@ -9,6 +9,7 @@ You must provide:
 * Content to sign. This may be a byte array, a stream, or a *FileInfo* object.
 * A certificate to sign with. This can be an *X509Certificate2* object or the SHA1 thumbprint of an installed certificate.
   * An *X509Certificate* object must include a private key to be used for signing.
+  * **Note**: When loading certificates from PFX files programmatically, if your PFX contains multiple certificates (such as a complete certificate chain), consider using the *SigningKeyProvider* with additional root certificates to ensure proper chain validation.
 
 You may also want to specify:
 * Detached or embedded: By default, CoseHandler creates a detached signature, which contains a hash of the original payoad. Setting ***embedSign=true*** creates an embedded signature, meaning that the signature file includes a copy of the payload as a byte array. Note that embedded signatures are only supported for payload of less than 2gb.

--- a/docs/CoseSignTool.md
+++ b/docs/CoseSignTool.md
@@ -12,6 +12,7 @@ The **Sign** command signs a file or stream.
 You will need to specify:
 * The payload content to sign. This may be a file specified with the **/Payload** option or you can pipe it in on the Standard Input channel when you call CoseSignTool. Piping in the content is generally considered more secure and performant option but large streams of > 2gb in length are not yet supported.
 * A certificate to sign with. You can either use the **/Thumbprint** option to pass the SHA1 thumbprint of an installed certificate or use the **/PfxCertificate** option to point to a .pfx certificate file and a **/Password** to open the certificate file with if it is locked. The certificate must include a private key.
+  * **PFX Certificate Chain Handling**: When using a PFX file that contains multiple certificates (such as a complete certificate chain), CoseSignTool will automatically use all certificates in the PFX for proper chain building. If you specify a **/Thumbprint** along with the PFX file, CoseSignTool will use the certificate matching that thumbprint for signing and treat the remaining certificates as additional roots for chain validation. If no thumbprint is specified, the first certificate with a private key will be used for signing.
 
 You may also want to specify:
 * Detached or embedded: By default, CoseSignTool creates a detached signature, which contains a hash of the original payoad. If you want it embedded, meaning that the signature file includes a copy of the payload, use the **/EmbedPayload option.** Note that embedded signatures are only supported for payload of less than 2gb.
@@ -72,6 +73,25 @@ The JSON schema is the same for both types of header files. Sample int32 and str
 ~~~
 
 Run *CoseSignTool sign /?* for the complete command line usage.
+
+### PFX Certificate Chain Examples
+
+**Sign with a PFX containing a certificate chain (uses first certificate with private key):**
+```bash
+CoseSignTool sign /p payload.txt /pfx certificates.pfx /pw password123 /sf signature.cose
+```
+
+**Sign with a specific certificate from a PFX chain using thumbprint:**
+```bash
+CoseSignTool sign /p payload.txt /pfx certificates.pfx /pw password123 /th A1B2C3D4E5F6789... /sf signature.cose
+```
+
+**Sign with embedded payload using PFX certificate chain:**
+```bash
+CoseSignTool sign /p payload.txt /pfx certificates.pfx /pw password123 /ep /sf signature.csm
+```
+
+When using these commands with a PFX file containing multiple certificates, CoseSignTool will automatically embed the complete certificate chain in the COSE signature, ensuring proper validation without requiring additional root certificates to be specified during validation.
 
 ## Validate
 The **Validate** command validates that a COSE signature is properly constructed, matches the signed payload, and roots to a valid certificate chain.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -6,6 +6,9 @@ The best way to 'shoot' trouble is to avoid it in the first place. The error mes
 * Make sure your certificates have not expired.
 * When signing with installed certificates you will get quicker lookups if you load the certificate from a custom store instead of from My/CurrentUser.
 * When signing with a loose certificate file, you should delete the file as soon as you are done signing with it to protect your private keys.
+* **PFX Certificate Chain Files**: When using a PFX file that contains multiple certificates (such as a complete certificate chain with root, intermediate, and leaf certificates), CoseSignTool will automatically extract and use all certificates for proper chain building. This ensures that the complete certificate chain is embedded in the COSE signature for proper validation.
+  * If you need to sign with a specific certificate from a multi-certificate PFX file, use the **/Thumbprint** option to specify which certificate to use for signing.
+  * The remaining certificates in the PFX will be used as additional roots for chain validation, ensuring proper trust chain establishment.
 
 ## Detached vs embedded signatures
 * Detached signatures are more efficient to produce than embeddeded signatures, have smaller file sizes, and are the only way to sign payloads larger than 2gb. In general, we recommend detached signing for most scenarios.
@@ -35,3 +38,4 @@ Do not include non-test certificates unless they are necessary to reproduce the 
 * If the certificates are publicly available, include the Common Names and Thumbprints, and a link to where you got them from if not from Microsoft.
 * If the certificates are proprietary, try to reproduce the issue with a similar set of test certificates and include those.
 * If you cannot reproduce the error with non-proprietary certificates, tell us and we will either try to diagnose the problem without the certificates or arrange a secure transfer.
+* **For PFX certificate chain issues**: Include information about how many certificates are in your PFX file, whether you're using a thumbprint to select a specific certificate, and the Common Names of the certificates in the chain (root, intermediate, leaf).


### PR DESCRIPTION
- Modified LoadCert method to return additional root certificates from PFX files.
- Updated SignCommand to utilize additional roots for signing key provider.
- Added examples and notes in documentation for handling PFX certificate chains.
- Improved troubleshooting guidance for PFX certificate chain usage.

Addresses issue: #137 