### PR TITLE
Move to central package management in the repo, also tabs to spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,9 @@ root = true
 
 # Default settings:
 [*]
+indent_style = space
+indent_size = 4
+tab_width = 4
 trim_trailing_whitespace = true
 insert_final_newline = false
 dotnet_style_coalesce_expression = true:suggestion
@@ -244,5 +247,21 @@ csharp_style_prefer_pattern_matching = true:silent
 csharp_style_prefer_not_pattern = true:suggestion
 csharp_style_prefer_extended_property_pattern = true:suggestion
 dotnet_diagnostic.IDE0043.severity = error
+
+# XML and project files
+[*.{xml,csproj,props,targets}]
+indent_style = space
+indent_size = 4
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
 csharp_style_prefer_top_level_statements = true:silent
 csharp_style_prefer_utf8_string_literals = true:suggestion

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,10 @@ This file ensures GitHub Copilot follows the repository's coding standards as de
 - **Using statements**: Prefer simple using statements over using blocks
 
 ### Formatting Rules
-- **Indentation**: 4 spaces (no tabs)
+- **Indentation**: **ALWAYS** use 4 spaces for indentation. **NEVER** use tabs.
+  - This applies to ALL file types: .cs, .csproj, .xml, .json, .md files
+  - Convert any existing tabs to 4 spaces
+  - Configure your editor to show whitespace to avoid accidental tab usage
 - **End of line**: CRLF (Windows line endings)
 - **Final newline**: Do not insert final newline
 - **Trim whitespace**: Always trim trailing whitespace

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -298,12 +298,12 @@ jobs:
         RUNTIME_ID=${{ matrix.runtime_id || '' }}
         if [ -n "$RUNTIME_ID" ]; then
           echo "Publishing for runtime: $RUNTIME_ID"
-          dotnet publish --configuration Debug --self-contained true --runtime $RUNTIME_ID --output published/debug --property:FileVersion=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
-          dotnet publish --configuration Release --self-contained true --runtime $RUNTIME_ID --output published/release --property:FileVersion=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
+          dotnet publish --configuration Debug --self-contained true --runtime $RUNTIME_ID --output published/debug --property:FileVersion=$VERSION --property:VersionNgt=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
+          dotnet publish --configuration Release --self-contained true --runtime $RUNTIME_ID --output published/release --property:FileVersion=$VERSION --property:VersionNgt=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
         else
           echo "Publishing for current platform"
-          dotnet publish --configuration Debug --self-contained true --output published/debug --property:FileVersion=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
-          dotnet publish --configuration Release --self-contained true --output published/release --property:FileVersion=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
+          dotnet publish --configuration Debug --self-contained true --output published/debug --property:FileVersion=$VERSION --property:VersionNgt=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
+          dotnet publish --configuration Release --self-contained true --output published/release --property:FileVersion=$VERSION --property:VersionNgt=$VERSION --property:DeployPlugins=true CoseSignTool/CoseSignTool.csproj
         fi
         # Self-contained is needed. Must use .csproj instead of .sln.
         # DeployPlugins=true enables automatic plugin deployment during publish
@@ -358,6 +358,7 @@ jobs:
               --configuration Release \
               --property:FileVersion=$VERSION \
               --property:PackageVersion=$VERSION \
+              --property:VersionNgt=$VERSION \
               --output published/packages \
               --verbosity minimal
             

--- a/.github/workflows/rerelease.yml
+++ b/.github/workflows/rerelease.yml
@@ -67,9 +67,9 @@ jobs:
 
           echo "**** Build and publish $tag ****"
           rm -rf published/debug
-          dotnet publish --configuration Debug --self-contained true --output published/debug CoseSignTool/CoseSignTool.csproj
+          dotnet publish --configuration Debug --self-contained true --output published/debug --property:VersionNgt=$tag CoseSignTool/CoseSignTool.csproj
           rm -rf published/release
-          dotnet publish --configuration Release --self-contained true --output published/release CoseSignTool/CoseSignTool.csproj
+          dotnet publish --configuration Release --self-contained true --output published/release --property:VersionNgt=$tag CoseSignTool/CoseSignTool.csproj
           echo "publish succeeded"
 
           echo "**** Copy documentation for $tag ****"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v1.6.1](https://github.com/microsoft/CoseSignTool/tree/v1.6.1) (2025-07-30)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.4-pre2...v1.6.1)
+
 ## [v1.5.4-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.5.4-pre2) (2025-07-30)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.6.0...v1.5.4-pre2)
@@ -19,20 +23,20 @@
 
 ## [v1.5.7](https://github.com/microsoft/CoseSignTool/tree/v1.5.7) (2025-07-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.6...v1.5.7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v.1.5.5...v1.5.7)
 
 **Merged pull requests:**
 
 - Enhance PFX certificate handling in SignCommand and update documentation [\#138](https://github.com/microsoft/CoseSignTool/pull/138) ([JeromySt](https://github.com/JeromySt))
 - Migrate from VSTest to MTP [\#124](https://github.com/microsoft/CoseSignTool/pull/124) ([Youssef1313](https://github.com/Youssef1313))
 
-## [v1.5.6](https://github.com/microsoft/CoseSignTool/tree/v1.5.6) (2025-07-15)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v.1.5.5...v1.5.6)
-
 ## [v.1.5.5](https://github.com/microsoft/CoseSignTool/tree/v.1.5.5) (2025-07-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.4-pre1...v.1.5.5)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.6...v.1.5.5)
+
+## [v1.5.6](https://github.com/microsoft/CoseSignTool/tree/v1.5.6) (2025-07-15)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.4-pre1...v1.5.6)
 
 ## [v1.5.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.4-pre1) (2025-07-15)
 
@@ -104,19 +108,19 @@
 
 ## [v1.4.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.4.0-pre1) (2025-04-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.4.0-pre1)
 
 **Merged pull requests:**
 
 - Added support for Transparency to CoseSign1 libraries to leverage services such as Azure Code Transparency Service [\#127](https://github.com/microsoft/CoseSignTool/pull/127) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.3.0-pre5)
-
 ## [v1.4.0](https://github.com/microsoft/CoseSignTool/tree/v1.4.0) (2025-03-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.4.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0)
+
+## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.3.0-pre5)
 
 **Merged pull requests:**
 
@@ -196,19 +200,19 @@
 
 ## [v1.2.8-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre3) (2024-10-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre2...v1.2.8-pre3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre1...v1.2.8-pre3)
 
 **Merged pull requests:**
 
 - Increase timeout for checking for empty streams [\#113](https://github.com/microsoft/CoseSignTool/pull/113) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.8-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre2) (2024-09-25)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre1...v1.2.8-pre2)
-
 ## [v1.2.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre1) (2024-09-25)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8...v1.2.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre2...v1.2.8-pre1)
+
+## [v1.2.8-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre2) (2024-09-25)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8...v1.2.8-pre2)
 
 **Merged pull requests:**
 
@@ -458,19 +462,19 @@
 
 ## [v1.1.5](https://github.com/microsoft/CoseSignTool/tree/v1.1.5) (2024-01-31)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.5)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.5)
 
 **Merged pull requests:**
 
 - write validation output to standard out [\#74](https://github.com/microsoft/CoseSignTool/pull/74) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.3-pre1) (2024-01-26)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.3-pre1)
-
 ## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.4)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.4)
+
+## [v1.1.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.3-pre1) (2024-01-26)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.3-pre1)
 
 **Merged pull requests:**
 
@@ -482,19 +486,19 @@
 
 ## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.2-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.2-pre1)
 
 **Merged pull requests:**
 
 - Updating snk for internal package compatibility [\#72](https://github.com/microsoft/CoseSignTool/pull/72) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.2](https://github.com/microsoft/CoseSignTool/tree/v1.1.2) (2024-01-18)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.2)
-
 ## [v1.1.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre2) (2024-01-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre1...v1.1.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.1-pre2)
+
+## [v1.1.2](https://github.com/microsoft/CoseSignTool/tree/v1.1.2) (2024-01-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre1...v1.1.2)
 
 **Merged pull requests:**
 
@@ -579,7 +583,7 @@
 
 ## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -589,13 +593,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
-
 ## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
+
+## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
 
 **Merged pull requests:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.5.4-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.5.4-pre2) (2025-07-30)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.6.0...v1.5.4-pre2)
+
+**Merged pull requests:**
+
+- Implement IndirectSignatures through CoseSignTool Plugin and iterate plugin architecture. [\#140](https://github.com/microsoft/CoseSignTool/pull/140) ([JeromySt](https://github.com/JeromySt))
+
 ## [v1.6.0](https://github.com/microsoft/CoseSignTool/tree/v1.6.0) (2025-07-18)
 
 [Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.7...v1.6.0)
@@ -60,31 +68,31 @@
 
 ## [v1.5.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.2-pre1) (2025-05-30)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.2...v1.5.2-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.1-pre1...v1.5.2-pre1)
 
 **Merged pull requests:**
 
 - Add optional header extender support to IndirectSignatureFactory methods [\#131](https://github.com/microsoft/CoseSignTool/pull/131) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.5.2](https://github.com/microsoft/CoseSignTool/tree/v1.5.2) (2025-05-29)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.1-pre1...v1.5.2)
-
 ## [v1.5.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.1-pre1) (2025-05-29)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0-pre1...v1.5.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.2...v1.5.1-pre1)
+
+## [v1.5.2](https://github.com/microsoft/CoseSignTool/tree/v1.5.2) (2025-05-29)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.1...v1.5.2)
 
 **Merged pull requests:**
 
 - feat: Add header extender support to IndirectSignatureFactory [\#130](https://github.com/microsoft/CoseSignTool/pull/130) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.5.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.0-pre1) (2025-05-07)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.1...v1.5.0-pre1)
-
 ## [v1.5.1](https://github.com/microsoft/CoseSignTool/tree/v1.5.1) (2025-05-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0...v1.5.1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0-pre1...v1.5.1)
+
+## [v1.5.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.5.0-pre1) (2025-05-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.5.0...v1.5.0-pre1)
 
 **Merged pull requests:**
 
@@ -96,19 +104,19 @@
 
 ## [v1.4.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.4.0-pre1) (2025-04-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.4.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0-pre1)
 
 **Merged pull requests:**
 
 - Added support for Transparency to CoseSign1 libraries to leverage services such as Azure Code Transparency Service [\#127](https://github.com/microsoft/CoseSignTool/pull/127) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.4.0](https://github.com/microsoft/CoseSignTool/tree/v1.4.0) (2025-03-18)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre5...v1.4.0)
-
 ## [v1.3.0-pre5](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre5) (2025-03-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.3.0-pre5)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.4.0...v1.3.0-pre5)
+
+## [v1.4.0](https://github.com/microsoft/CoseSignTool/tree/v1.4.0) (2025-03-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0-pre4...v1.4.0)
 
 **Merged pull requests:**
 
@@ -140,19 +148,19 @@
 
 ## [v1.3.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.3.0-pre1) (2024-11-20)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre7...v1.3.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.0.0-Test1...v1.3.0-pre1)
 
 **Merged pull requests:**
 
 - Set file versions in release workflow [\#120](https://github.com/microsoft/CoseSignTool/pull/120) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.8-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre7) (2024-10-30)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.0.0-Test1...v1.2.8-pre7)
-
 ## [v0.0.0-Test1](https://github.com/microsoft/CoseSignTool/tree/v0.0.0-Test1) (2024-10-30)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0...v0.0.0-Test1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.8-pre7...v0.0.0-Test1)
+
+## [v1.2.8-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.2.8-pre7) (2024-10-30)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.3.0...v1.2.8-pre7)
 
 **Merged pull requests:**
 
@@ -250,19 +258,19 @@
 
 ## [v1.2.5-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.5-pre1) (2024-08-14)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.5...v1.2.5-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4-pre3...v1.2.5-pre1)
 
 **Merged pull requests:**
 
 - Update package dependencies [\#99](https://github.com/microsoft/CoseSignTool/pull/99) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.5](https://github.com/microsoft/CoseSignTool/tree/v1.2.5) (2024-08-06)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4-pre3...v1.2.5)
-
 ## [v1.2.4-pre3](https://github.com/microsoft/CoseSignTool/tree/v1.2.4-pre3) (2024-08-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4-pre2...v1.2.4-pre3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.5...v1.2.4-pre3)
+
+## [v1.2.5](https://github.com/microsoft/CoseSignTool/tree/v1.2.5) (2024-08-06)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.4-pre2...v1.2.5)
 
 **Merged pull requests:**
 
@@ -350,19 +358,19 @@
 
 ## [v1.2.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre2) (2024-03-15)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.1-pre2)
 
 **Merged pull requests:**
 
 - more granular error codes [\#86](https://github.com/microsoft/CoseSignTool/pull/86) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1-pre1...v1.2.2)
-
 ## [v1.2.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.2.1-pre1) (2024-03-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.2...v1.2.1-pre1)
+
+## [v1.2.2](https://github.com/microsoft/CoseSignTool/tree/v1.2.2) (2024-03-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.1...v1.2.2)
 
 **Merged pull requests:**
 
@@ -382,15 +390,15 @@
 
 ## [v1.2.exeTest](https://github.com/microsoft/CoseSignTool/tree/v1.2.exeTest) (2024-03-06)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.2.exeTest)
-
-## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.8-pre1...v1.2.exeTest)
 
 ## [v1.1.8-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.8-pre1) (2024-03-04)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7-pre3...v1.1.8-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.2.0...v1.1.8-pre1)
+
+## [v1.2.0](https://github.com/microsoft/CoseSignTool/tree/v1.2.0) (2024-03-04)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7-pre3...v1.2.0)
 
 **Merged pull requests:**
 
@@ -418,19 +426,19 @@
 
 ## [v1.1.7-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.7-pre1) (2024-02-14)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6-pre1...v1.1.7-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7...v1.1.7-pre1)
 
 **Merged pull requests:**
 
 - Command Line Validation of Indirect Signatures [\#78](https://github.com/microsoft/CoseSignTool/pull/78) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.6-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.6-pre1) (2024-02-07)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.7...v1.1.6-pre1)
-
 ## [v1.1.7](https://github.com/microsoft/CoseSignTool/tree/v1.1.7) (2024-02-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6...v1.1.7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6-pre1...v1.1.7)
+
+## [v1.1.6-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.6-pre1) (2024-02-07)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.6...v1.1.6-pre1)
 
 **Merged pull requests:**
 
@@ -438,55 +446,55 @@
 
 ## [v1.1.6](https://github.com/microsoft/CoseSignTool/tree/v1.1.6) (2024-02-07)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.5...v1.1.6)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4-pre1...v1.1.6)
 
 **Merged pull requests:**
 
 - Only hit iterator once [\#75](https://github.com/microsoft/CoseSignTool/pull/75) ([JeromySt](https://github.com/JeromySt))
 
-## [v1.1.5](https://github.com/microsoft/CoseSignTool/tree/v1.1.5) (2024-01-31)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4-pre1...v1.1.5)
-
 ## [v1.1.4-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.4-pre1) (2024-01-31)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.4-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.5...v1.1.4-pre1)
+
+## [v1.1.5](https://github.com/microsoft/CoseSignTool/tree/v1.1.5) (2024-01-31)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.5)
 
 **Merged pull requests:**
 
 - write validation output to standard out [\#74](https://github.com/microsoft/CoseSignTool/pull/74) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3-pre1...v1.1.4)
-
 ## [v1.1.3-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.3-pre1) (2024-01-26)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.3-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.4...v1.1.3-pre1)
+
+## [v1.1.4](https://github.com/microsoft/CoseSignTool/tree/v1.1.4) (2024-01-26)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.4)
 
 **Merged pull requests:**
 
 - Adding Validation Option to Output Certificate Chain [\#73](https://github.com/microsoft/CoseSignTool/pull/73) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.3...v1.1.2-pre1)
-
 ## [v1.1.3](https://github.com/microsoft/CoseSignTool/tree/v1.1.3) (2024-01-24)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.3)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2-pre1...v1.1.3)
+
+## [v1.1.2-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.2-pre1) (2024-01-24)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.2-pre1)
 
 **Merged pull requests:**
 
 - Updating snk for internal package compatibility [\#72](https://github.com/microsoft/CoseSignTool/pull/72) ([elantiguamsft](https://github.com/elantiguamsft))
 
-## [v1.1.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre2) (2024-01-18)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.2...v1.1.1-pre2)
-
 ## [v1.1.2](https://github.com/microsoft/CoseSignTool/tree/v1.1.2) (2024-01-18)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre1...v1.1.2)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre2...v1.1.2)
+
+## [v1.1.1-pre2](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre2) (2024-01-18)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1-pre1...v1.1.1-pre2)
 
 **Merged pull requests:**
 
@@ -494,19 +502,19 @@
 
 ## [v1.1.1-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1-pre1) (2024-01-17)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.1-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1-pre1)
 
 **Merged pull requests:**
 
 - Move CreateChangelog to after build in PR build [\#70](https://github.com/microsoft/CoseSignTool/pull/70) ([lemccomb](https://github.com/lemccomb))
 
-## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre7...v1.1.1)
-
 ## [v1.1.0-pre7](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre7) (2024-01-12)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.0-pre7)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.1...v1.1.0-pre7)
+
+## [v1.1.1](https://github.com/microsoft/CoseSignTool/tree/v1.1.1) (2024-01-12)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0-pre6...v1.1.1)
 
 **Merged pull requests:**
 
@@ -555,7 +563,7 @@
 
 ## [v1.1.0-pre1](https://github.com/microsoft/CoseSignTool/tree/v1.1.0-pre1) (2023-11-03)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0-pre1)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v1.1.0-pre1)
 
 **Merged pull requests:**
 
@@ -565,13 +573,13 @@
 - DetachedSignatureFactory accepts pre-hashed content as payload [\#53](https://github.com/microsoft/CoseSignTool/pull/53) ([elantiguamsft](https://github.com/elantiguamsft))
 - Add password support for certificate files [\#52](https://github.com/microsoft/CoseSignTool/pull/52) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v1.1.0...v0.3.1-pre.10)
-
 ## [v1.1.0](https://github.com/microsoft/CoseSignTool/tree/v1.1.0) (2023-10-10)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v1.1.0)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.10...v1.1.0)
+
+## [v0.3.1-pre.10](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.10) (2023-10-10)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.1-pre.10)
 
 **Merged pull requests:**
 
@@ -581,13 +589,13 @@
 - Port changes from ADO repo to GitHub repo [\#46](https://github.com/microsoft/CoseSignTool/pull/46) ([lemccomb](https://github.com/lemccomb))
 - Re-enable CodeQL [\#45](https://github.com/microsoft/CoseSignTool/pull/45) ([lemccomb](https://github.com/lemccomb))
 
-## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
-
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.9...v0.3.2)
-
 ## [v0.3.1-pre.9](https://github.com/microsoft/CoseSignTool/tree/v0.3.1-pre.9) (2023-09-28)
 
-[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.1-pre.9)
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.2...v0.3.1-pre.9)
+
+## [v0.3.2](https://github.com/microsoft/CoseSignTool/tree/v0.3.2) (2023-09-28)
+
+[Full Changelog](https://github.com/microsoft/CoseSignTool/compare/v0.3.1-pre.8...v0.3.2)
 
 **Merged pull requests:**
 

--- a/CoseHandler.Tests/CoseHandler.Tests.csproj
+++ b/CoseHandler.Tests/CoseHandler.Tests.csproj
@@ -1,39 +1,38 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
-		<IsPackable>false</IsPackable>
-		<IsPublishable>false</IsPublishable>
-		<IsTestProject>true</IsTestProject>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<Nullable>enable</Nullable>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-		<RootNamespace>CoseSignUnitTests</RootNamespace>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+        <IsTestProject>true</IsTestProject>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <Nullable>enable</Nullable>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+        <RootNamespace>CoseSignUnitTests</RootNamespace>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Because this is a test project, don't run code coverage -->
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
+    <ItemGroup>
+        <!-- Because this is a test project, don't run code coverage -->
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
 
-	<!-- Package references -->
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <!-- Package references -->
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="MSTest.TestAdapter" />
+        <PackageReference Include="MSTest.TestFramework" />
+    </ItemGroup>
 
-	</ItemGroup>
-
-	<!-- Project refrences-->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
-		<ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
-	</ItemGroup>
+    <!-- Project refrences-->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
+        <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseHandler/CoseHandler.csproj
+++ b/CoseHandler/CoseHandler.csproj
@@ -1,56 +1,56 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>.NET API to sign files using COSE Sign1 message envelopes in a way that is compatible with Supply Chain Integrity Transparency and Trust (SCITT).</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>.NET API to sign files using COSE Sign1 message envelopes in a way that is compatible with Supply Chain Integrity Transparency and Trust (SCITT).</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
+    <!--Package references-->
 
-	<!--Project references-->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
-		<ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+    <!--Project references-->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
+        <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+        <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
     <ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
-	</ItemGroup>
+    </ItemGroup>
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
 </Project>

--- a/CoseIndirectSignature.Tests/CoseIndirectSignature.Tests.csproj
+++ b/CoseIndirectSignature.Tests/CoseIndirectSignature.Tests.csproj
@@ -1,46 +1,46 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<IsPublishable>false</IsPublishable>
-		<LangVersion>latest</LangVersion>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+        <LangVersion>latest</LangVersion>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Because this is a test project, don't run code coverage -->
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
+    <ItemGroup>
+        <!-- Because this is a test project, don't run code coverage -->
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
 
-	<!-- Package references -->
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
-		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.9.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+    <!-- Package references -->
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="MSTest.TestFramework" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 
-	<!-- Project references -->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
-		<ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
-	</ItemGroup>
+    <!-- Project references -->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
+        <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseIndirectSignature/CoseIndirectSignature.csproj
+++ b/CoseIndirectSignature/CoseIndirectSignature.csproj
@@ -1,66 +1,66 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>Abstractions and classes required to manage indirect signatures via COSE Sign1 message envelopes in a way that is compatible with Supply Chain Integrity Transparency and Trust (SCITT).</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>Abstractions and classes required to manage indirect signatures via COSE Sign1 message envelopes in a way that is compatible with Supply Chain Integrity Transparency and Trust (SCITT).</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
-	<ItemGroup>
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-	</ItemGroup>
+    <!--Package references-->
+    <ItemGroup>
+        <PackageReference Include="System.Threading.Tasks.Extensions" />
+    </ItemGroup>
 
-	<!--Project references-->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
-		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
-	</ItemGroup>
+    <!--Project references-->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
+        <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+    </ItemGroup>
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>
-				CoseIndirectSignature.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9
-			</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>
+                CoseIndirectSignature.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9
+            </_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
+++ b/CoseSign1.Abstractions/CoseSign1.Abstractions.csproj
@@ -1,51 +1,51 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>Abstractions required to extend or enhance Create CoseSign1 functionality.</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>Abstractions required to extend or enhance Create CoseSign1 functionality.</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
-	<ItemGroup>
-		<PackageReference Include="System.Security.Cryptography.Cose" Version="9.0.7" />
-	</ItemGroup>
+    <!--Package references-->
+    <ItemGroup>
+        <PackageReference Include="System.Security.Cryptography.Cose" />
+    </ItemGroup>
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
 </Project>

--- a/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
+++ b/CoseSign1.Certificates.Tests/CoseSign1.Certificates.Tests.csproj
@@ -1,45 +1,45 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<IsPublishable>false</IsPublishable>
-		<LangVersion>latest</LangVersion>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+        <LangVersion>latest</LangVersion>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Because this is a test project, don't run code coverage -->
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
+    <ItemGroup>
+        <!-- Because this is a test project, don't run code coverage -->
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
 
-	<!-- Package references -->
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <!-- Package references -->
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="MSTest.TestFramework" />
 
-		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.9.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Moq" />
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 
-	<!-- Project references -->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-		<ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
-		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
-	</ItemGroup>
+    <!-- Project references -->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+        <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
+        <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1.Certificates/CoseSign1.Certificates.csproj
+++ b/CoseSign1.Certificates/CoseSign1.Certificates.csproj
@@ -1,55 +1,55 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2;net8.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2;net8.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>Abstractions and classes required to extend or enhance Microsoft.CoseSign1.Abstractions for all certificate based signing.</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>Abstractions and classes required to extend or enhance Microsoft.CoseSign1.Abstractions for all certificate based signing.</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
-	<ItemGroup>
-		<PackageReference Include="System.Runtime.Caching" Version="9.0.7" />
-	</ItemGroup>
+    <!--Package references-->
+    <ItemGroup>
+        <PackageReference Include="System.Runtime.Caching" />
+    </ItemGroup>
 
-	<!--Project references-->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-	</ItemGroup>
+    <!--Project references-->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+    </ItemGroup>
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
 </Project>

--- a/CoseSign1.Headers.Tests/CoseSign1.Headers.Tests.csproj
+++ b/CoseSign1.Headers.Tests/CoseSign1.Headers.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -18,16 +18,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
-        <PackageReference Include="NUnit" Version="4.3.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="MSTest.TestFramework" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="Moq" />
+        <PackageReference Include="coverlet.collector">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/CoseSign1.Headers/CoseSign1.Headers.csproj
+++ b/CoseSign1.Headers/CoseSign1.Headers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <!--Build configuration-->
     <PropertyGroup>
@@ -38,7 +38,7 @@
     <!--Project references-->
     <ItemGroup>
         <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-        <PackageReference Include="System.Text.Json" Version="9.0.7" />
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 
     <!--Files to include in the package-->

--- a/CoseSign1.Tests.Common/CoseSign1.Tests.Common.csproj
+++ b/CoseSign1.Tests.Common/CoseSign1.Tests.Common.csproj
@@ -1,22 +1,22 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<IsPublishable>false</IsPublishable>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPublishable>false</IsPublishable>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Because this is a test project, don't run code coverage -->
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
+    <ItemGroup>
+        <!-- Because this is a test project, don't run code coverage -->
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1.Tests/CoseSign1.Tests.csproj
+++ b/CoseSign1.Tests/CoseSign1.Tests.csproj
@@ -1,48 +1,48 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-		<IsPublishable>false</IsPublishable>
-		<LangVersion>latest</LangVersion>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+        <LangVersion>latest</LangVersion>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Because this is a test project, don't run code coverage -->
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
+    <ItemGroup>
+        <!-- Because this is a test project, don't run code coverage -->
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
 
-	<!-- Package references -->
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <!-- Package references -->
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="MSTest.TestFramework" />
 
-		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.9.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="System.Security.Cryptography.Cose" Version="9.0.7" />
-	</ItemGroup>
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="NUnit.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Security.Cryptography.Cose" />
+    </ItemGroup>
 
-	<!-- Project references -->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
-		<ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-		<ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-		<ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
-		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
-	</ItemGroup>
+    <!-- Project references -->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseIndirectSignature\CoseIndirectSignature.csproj" />
+        <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+        <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+        <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
+        <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1.Transparent.CTS.Tests/CoseSign1.Transparent.CTS.Tests.csproj
+++ b/CoseSign1.Transparent.CTS.Tests/CoseSign1.Transparent.CTS.Tests.csproj
@@ -1,39 +1,39 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
 
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-	</PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Azure.Core" Version="1.47.1" />
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="NUnit" Version="4.3.2" />
-		<PackageReference Include="NUnit.Analyzers" Version="4.9.2">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Azure.Core" />
+        <PackageReference Include="coverlet.collector">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-		<ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
-		<ProjectReference Include="..\CoseSign1.Transparent.CTS\CoseSign1.Transparent.CTS.csproj" />
-		<ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+        <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
+        <ProjectReference Include="..\CoseSign1.Transparent.CTS\CoseSign1.Transparent.CTS.csproj" />
+        <ProjectReference Include="..\CoseSign1\CoseSign1.csproj" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<Using Include="NUnit.Framework" />
-	</ItemGroup>
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1.Transparent.CTS/CoseSign1.Transparent.CTS.csproj
+++ b/CoseSign1.Transparent.CTS/CoseSign1.Transparent.CTS.csproj
@@ -1,57 +1,57 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>Extensions to CoseSign1.Transparent to enable Azure Code Transparency Service (CTS) as a transparency registration and validation service.</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>Extensions to CoseSign1.Transparent to enable Azure Code Transparency Service (CTS) as a transparency registration and validation service.</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
+    <!--Package references-->
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
-	<ItemGroup>
-	  <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.3">
-		<NoWarn>NU5104</NoWarn>
-	  </PackageReference>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Transparent\CoseSign1.Transparent.csproj" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Azure.Security.CodeTransparency">
+        <NoWarn>NU5104</NoWarn>
+      </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Transparent\CoseSign1.Transparent.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1.Transparent.Tests/CoseSign1.Transparent.Tests.csproj
+++ b/CoseSign1.Transparent.Tests/CoseSign1.Transparent.Tests.csproj
@@ -10,18 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoseSign1.Transparent/CoseSign1.Transparent.csproj
+++ b/CoseSign1.Transparent/CoseSign1.Transparent.csproj
@@ -1,52 +1,52 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>Extensions to CoseSign1Message to enable Transparency registration and validation.</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>Extensions to CoseSign1Message to enable Transparency registration and validation.</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
+    <!--Package references-->
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
-	<ItemGroup>
-	  <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/CoseSign1/CoseSign1.csproj
+++ b/CoseSign1/CoseSign1.csproj
@@ -1,55 +1,55 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<!--Build configuration-->
-	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+    <!--Build configuration-->
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-	<!--Code style and static analysis-->
-	<PropertyGroup>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<Nullable>enable</Nullable>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
+    <!--Code style and static analysis-->
+    <PropertyGroup>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <Nullable>enable</Nullable>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-	<!--Strong name signing-->
-	<PropertyGroup>
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>True</DelaySign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!--Strong name signing-->
+    <PropertyGroup>
+        <SignAssembly>True</SignAssembly>
+        <DelaySign>True</DelaySign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<!--NuGet package configuration-->
-	<PropertyGroup>
-		<PackageId>$(MsBuildProjectName)</PackageId>
-		<PackageVersion>$(VersionNgt)</PackageVersion>
-		<Company>Microsoft</Company>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
-		<Description>Factory Implementations required to Create a CoseSign1 Message.</Description>
-	</PropertyGroup>
+    <!--NuGet package configuration-->
+    <PropertyGroup>
+        <PackageId>$(MsBuildProjectName)</PackageId>
+        <PackageVersion>$(VersionNgt)</PackageVersion>
+        <Company>Microsoft</Company>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageReleaseNotes>ChangeLog.md</PackageReleaseNotes>
+        <Description>Factory Implementations required to Create a CoseSign1 Message.</Description>
+    </PropertyGroup>
 
-	<!--Package references-->
-	<ItemGroup>
-	</ItemGroup>
+    <!--Package references-->
+    <ItemGroup>
+    </ItemGroup>
 
-	<!--Project references-->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
-	</ItemGroup>
+    <!--Project references-->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Abstractions\CoseSign1.Abstractions.csproj" />
+    </ItemGroup>
 
-	<!--Files to include in the package-->
-	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="\" />
-		<None Include="..\readme.md" Pack="true" PackagePath="\" />
-		<None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
-		<None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
-		<None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
-	</ItemGroup>
+    <!--Files to include in the package-->
+    <ItemGroup>
+        <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\readme.md" Pack="true" PackagePath="\" />
+        <None Include="..\ChangeLog.md" Pack="true" PackagePath="\" />
+        <None Include="..\docs\*.md" Pack="true" PackagePath="\docs\" />
+        <None Include="\bin\Release\net8.0\_manifest\spdx_2.2\*.*" Condition="Exists('\bin\Release\net8.0\_manifest\spdx_2.2\*.*')" Pack="true" PackagePath="Build\sbom\spdx_2.2" />
+    </ItemGroup>
 </Project>

--- a/CoseSignTool.Abstractions.Tests/CoseSignTool.Abstractions.Tests.csproj
+++ b/CoseSignTool.Abstractions.Tests/CoseSignTool.Abstractions.Tests.csproj
@@ -19,15 +19,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoseSignTool.Abstractions/CoseSignTool.Abstractions.csproj
+++ b/CoseSignTool.Abstractions/CoseSignTool.Abstractions.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
     <ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/CoseSignTool.CTS.Plugin.Tests/CoseSignTool.CTS.Plugin.Tests.csproj
+++ b/CoseSignTool.CTS.Plugin.Tests/CoseSignTool.CTS.Plugin.Tests.csproj
@@ -19,16 +19,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Azure.Core" Version="1.47.1" />
-    <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.3">
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Security.CodeTransparency">
       <NoWarn>NU5104</NoWarn>
     </PackageReference>
   </ItemGroup>

--- a/CoseSignTool.CTS.Plugin/CoseSignTool.CTS.Plugin.csproj
+++ b/CoseSignTool.CTS.Plugin/CoseSignTool.CTS.Plugin.csproj
@@ -32,20 +32,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.47.1">
+    <PackageReference Include="Azure.Core">
       <Private>true</Private>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Azure.Identity" Version="1.14.2">
+    <PackageReference Include="Azure.Identity">
       <Private>true</Private>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.3">
+    <PackageReference Include="Azure.Security.CodeTransparency">
       <NoWarn>NU5104</NoWarn>
       <Private>true</Private>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7">
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine">
       <Private>true</Private>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </PackageReference>

--- a/CoseSignTool.IndirectSignature.Plugin.Tests/CoseSignTool.IndirectSignature.Plugin.Tests.csproj
+++ b/CoseSignTool.IndirectSignature.Plugin.Tests/CoseSignTool.IndirectSignature.Plugin.Tests.csproj
@@ -18,14 +18,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoseSignTool.IndirectSignature.Plugin/CoseSignTool.IndirectSignature.Plugin.csproj
+++ b/CoseSignTool.IndirectSignature.Plugin/CoseSignTool.IndirectSignature.Plugin.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoseSignTool.Tests/CoseSignTool.Tests.csproj
+++ b/CoseSignTool.Tests/CoseSignTool.Tests.csproj
@@ -1,56 +1,56 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<Platforms>AnyCPU</Platforms>
-		<!-- must match the platform set from CoseSignTool	-->
-		<Nullable>enable</Nullable>
-		<IsPublishable>false</IsPublishable>
-		<EnablePreviewFeatures>true</EnablePreviewFeatures>
-		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-		<SignAssembly>True</SignAssembly>
-		<PublicSign>True</PublicSign>
-		<AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Platforms>AnyCPU</Platforms>
+        <!-- must match the platform set from CoseSignTool    -->
+        <Nullable>enable</Nullable>
+        <IsPublishable>false</IsPublishable>
+        <EnablePreviewFeatures>true</EnablePreviewFeatures>
+        <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+        <SignAssembly>True</SignAssembly>
+        <PublicSign>True</PublicSign>
+        <AssemblyOriginatorKeyFile>..\StrongNameKeys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
 
-	<PropertyGroup>
-		<!-- other property settings -->
-		<ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-		<TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
-	</PropertyGroup>
+    <PropertyGroup>
+        <!-- other property settings -->
+        <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+        <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<!-- Because this is a test project, don't run code coverage -->
-		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
-	</ItemGroup>
+    <ItemGroup>
+        <!-- Because this is a test project, don't run code coverage -->
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+    </ItemGroup>
 
-	<!-- Package references -->
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <!-- Package references -->
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="MSTest.TestAdapter" />
+        <PackageReference Include="MSTest.TestFramework" />
 
-	</ItemGroup>
+    </ItemGroup>
 
-	<!-- Project references -->
-	<ItemGroup>
-		<ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
-		<ProjectReference Include="..\CoseSignTool\CoseSignTool.csproj" />
-	</ItemGroup>
+    <!-- Project references -->
+    <ItemGroup>
+        <ProjectReference Include="..\CoseSign1.Tests.Common\CoseSign1.Tests.Common.csproj" />
+        <ProjectReference Include="..\CoseSignTool\CoseSignTool.csproj" />
+    </ItemGroup>
 
-	<!-- File Includes -->
-	<ItemGroup>
-	  <None Update="..\CoseSignTool.Tests\TestData\UnitTestPayload.json" />
-	  <None Update="..\CoseSignTool.Tests\TestData\UnitTestSignatureWithCRL.cose" />
-	</ItemGroup>
+    <!-- File Includes -->
+    <ItemGroup>
+      <None Update="..\CoseSignTool.Tests\TestData\UnitTestPayload.json" />
+      <None Update="..\CoseSignTool.Tests\TestData\UnitTestSignatureWithCRL.cose" />
+    </ItemGroup>
 
-	<!-- Copy test files to output. This explicit target is needed for linux build/test agents -->
-	<Target Name="CopyCustomContent" AfterTargets="AfterBuild">
-		<ItemGroup>
-			<TestFiles Include="..\CoseSignTool.Tests\TestData\**\*.*" />
-		</ItemGroup>
-		<Copy SourceFiles="@(TestFiles)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
-		<Message Importance="High" Text="+++++++++++++++++++++++ Copied @(TestFiles) to $(TargetDir). ++++++++++++++++++++++++++++++++++++" />
-	</Target>	  			  	
+    <!-- Copy test files to output. This explicit target is needed for linux build/test agents -->
+    <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
+        <ItemGroup>
+            <TestFiles Include="..\CoseSignTool.Tests\TestData\**\*.*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(TestFiles)" DestinationFolder="$(TargetDir)" SkipUnchangedFiles="true" />
+        <Message Importance="High" Text="+++++++++++++++++++++++ Copied @(TestFiles) to $(TargetDir). ++++++++++++++++++++++++++++++++++++" />
+    </Target>                        
 
 </Project>

--- a/CoseSignTool/CoseSignTool.csproj
+++ b/CoseSignTool/CoseSignTool.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <!--Build configuration-->
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -48,7 +48,7 @@
 
     <!--Package references-->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     </ItemGroup>
 
     <!--Project references-->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
+    <!-- Central package management is enabled via Directory.Packages.props -->
     <EnableNUnitRunner>true</EnableNUnitRunner>
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,44 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Core Framework Packages -->
+  <ItemGroup>
+    <PackageVersion Include="System.Security.Cryptography.Cose" Version="9.0.7" />
+    <PackageVersion Include="System.Runtime.Caching" Version="9.0.7" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.7" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+  </ItemGroup>
+
+  <!-- Microsoft Extensions -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
+  </ItemGroup>
+
+  <!-- Azure Packages -->
+  <ItemGroup>
+    <PackageVersion Include="Azure.Core" Version="1.47.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
+    <PackageVersion Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.3" />
+  </ItemGroup>
+
+  <!-- Testing Framework Packages -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.9.2" />
+  </ItemGroup>
+
+  <!-- Testing Utility Packages -->
+  <ItemGroup>
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Migrate repo to central package management for easier dependency management.