### PR TITLE
Add --payload-location option for IndirectSignature

### DIFF
--- a/CoseIndirectSignature/IndirectSignatureFactory.CoseHashEnvelope.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.CoseHashEnvelope.cs
@@ -19,6 +19,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="bytePayload">If streamPayload is null then this must be specified and must not be null and will use the Byte API's on the CoseSign1MesssageFactory</param>
     /// <param name="payloadHashed">True if the payload represents the raw hash</param>
     /// <param name="headerExtender">Optional header extender to add custom headers to the COSE message.</param>
+    /// <param name="payloadLocation">Optional URI indicating where the payload can be retrieved from.</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
@@ -30,7 +31,8 @@ public sealed partial class IndirectSignatureFactory
         Stream? streamPayload = null,
         ReadOnlyMemory<byte>? bytePayload = null,
         bool payloadHashed = false,
-        ICoseHeaderExtender? headerExtender = null)
+        ICoseHeaderExtender? headerExtender = null,
+        string? payloadLocation = null)
     {
         ReadOnlyMemory<byte> hash;
         HashAlgorithmName algoName = InternalHashAlgorithmName;
@@ -57,8 +59,8 @@ public sealed partial class IndirectSignatureFactory
         }
 
         ICoseHeaderExtender effectiveHeaderExtender = headerExtender == null ?
-            new CoseHashEnvelopeHeaderExtender(algoName, contentType, null) :
-            new CoseSign1.Headers.ChainedCoseHeaderExtender(new[] { headerExtender, new CoseHashEnvelopeHeaderExtender(algoName, contentType, null) });
+            new CoseHashEnvelopeHeaderExtender(algoName, contentType, payloadLocation) :
+            new CoseSign1.Headers.ChainedCoseHeaderExtender(new[] { headerExtender, new CoseHashEnvelopeHeaderExtender(algoName, contentType, payloadLocation) });
 
         return returnBytes
                ? InternalMessageFactory.CreateCoseSign1MessageBytes(
@@ -84,7 +86,8 @@ public sealed partial class IndirectSignatureFactory
         ReadOnlyMemory<byte>? bytePayload = null,
         bool payloadHashed = false,
         ICoseHeaderExtender? headerExtender = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? payloadLocation = null)
     {
         // Check for cancellation before starting expensive hash computation
         cancellationToken.ThrowIfCancellationRequested();
@@ -117,8 +120,8 @@ public sealed partial class IndirectSignatureFactory
         }
 
         ICoseHeaderExtender effectiveHeaderExtender = headerExtender == null ?
-            new CoseHashEnvelopeHeaderExtender(algoName, contentType, null) :
-            new CoseSign1.Headers.ChainedCoseHeaderExtender(new[] { headerExtender, new CoseHashEnvelopeHeaderExtender(algoName, contentType, null) });
+            new CoseHashEnvelopeHeaderExtender(algoName, contentType, payloadLocation) :
+            new CoseSign1.Headers.ChainedCoseHeaderExtender(new[] { headerExtender, new CoseHashEnvelopeHeaderExtender(algoName, contentType, payloadLocation) });
 
         return returnBytes
                ? await InternalMessageFactory.CreateCoseSign1MessageBytesAsync(

--- a/CoseIndirectSignature/IndirectSignatureFactory.Stream.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.Stream.cs
@@ -185,6 +185,7 @@ public sealed partial class IndirectSignatureFactory
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
     /// <param name="coseHeaderExtender">Optional header extender to add custom headers to the COSE message.</param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <param name="payloadLocation">Optional URI indicating where the payload can be retrieved from. Only applicable for CoseHashEnvelope format.</param>
     /// <returns>A Task which can be awaited which will return a CoseSign1Message which can be used as a Indirect signature validation of the payload.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     public async Task<CoseSign1Message> CreateIndirectSignatureAsync(
@@ -193,7 +194,8 @@ public sealed partial class IndirectSignatureFactory
         string contentType,
         IndirectSignatureVersion signatureVersion,
         ICoseHeaderExtender? coseHeaderExtender = null,
-        CancellationToken cancellationToken = default) =>
+        CancellationToken cancellationToken = default,
+        string? payloadLocation = null) =>
             (CoseSign1Message)await CreateIndirectSignatureWithChecksInternalAsync(
                 returnBytes: false,
                 signingKeyProvider: signingKeyProvider,
@@ -201,7 +203,8 @@ public sealed partial class IndirectSignatureFactory
                 streamPayload: payload,
                 signatureVersion: signatureVersion,
                 headerExtender: coseHeaderExtender,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+                cancellationToken: cancellationToken,
+                payloadLocation: payloadLocation).ConfigureAwait(false);
 
     /// <summary>
     /// Creates a Indirect signature of the payload given a hash of the payload returned as a <see cref="CoseSign1Message"/> following the rules in this class description.

--- a/CoseIndirectSignature/IndirectSignatureFactory.cs
+++ b/CoseIndirectSignature/IndirectSignatureFactory.cs
@@ -109,6 +109,7 @@ public sealed partial class IndirectSignatureFactory : IDisposable
     /// <param name="payloadHashed">True if the payload represents the raw hash</param>
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
     /// <param name="headerExtender">An optional <see cref="ICoseHeaderExtender"/> to extend the protected headers of the CoseSign1Message.</param>
+    /// <param name="payloadLocation">Optional URI indicating where the payload can be retrieved from. Only applicable for CoseHashEnvelope format.</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
@@ -121,7 +122,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
         Stream? streamPayload = null,
         ReadOnlyMemory<byte>? bytePayload = null,
         bool payloadHashed = false,
-        ICoseHeaderExtender? headerExtender = null)
+        ICoseHeaderExtender? headerExtender = null,
+        string? payloadLocation = null)
     {
         if (string.IsNullOrWhiteSpace(contentType))
         {
@@ -166,7 +168,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
                             streamPayload,
                             bytePayload,
                             payloadHashed,
-                            headerExtender);
+                            headerExtender,
+                            payloadLocation);
             default:
                 throw new ArgumentOutOfRangeException(nameof(signatureVersion), "Unknown signature version");
         }
@@ -184,6 +187,7 @@ public sealed partial class IndirectSignatureFactory : IDisposable
     /// <param name="signatureVersion">The <see cref="IndirectSignatureVersion"/> this factory should create.</param>
     /// <param name="headerExtender">An optional <see cref="ICoseHeaderExtender"/> to extend the protected headers of the CoseSign1Message.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <param name="payloadLocation">Optional URI indicating where the payload can be retrieved from. Only applicable for CoseHashEnvelope format.</param>
     /// <returns>Either a CoseSign1Message or a ReadOnlyMemory{byte} representing the CoseSign1Message object.</returns>
     /// <exception cref="ArgumentNullException">The contentType parameter was empty or null</exception>
     /// <exception cref="ArgumentNullException">Either streamPayload or bytePayload must be specified, but not both at the same time, or both cannot be null</exception>
@@ -197,7 +201,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
         ReadOnlyMemory<byte>? bytePayload = null,
         bool payloadHashed = false,
         ICoseHeaderExtender? headerExtender = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? payloadLocation = null)
     {
         if (string.IsNullOrWhiteSpace(contentType))
         {
@@ -245,7 +250,8 @@ public sealed partial class IndirectSignatureFactory : IDisposable
                             bytePayload,
                             payloadHashed,
                             headerExtender,
-                            cancellationToken).ConfigureAwait(false);
+                            cancellationToken,
+                            payloadLocation).ConfigureAwait(false);
             default:
                 throw new ArgumentOutOfRangeException(nameof(signatureVersion), "Unknown signature version");
         }

--- a/docs/IndirectSignaturePlugin.md
+++ b/docs/IndirectSignaturePlugin.md
@@ -67,6 +67,7 @@ For comprehensive SCITT documentation, see [SCITTCompliance.md](./SCITTComplianc
 - `--content-type`: The content type of the payload (default: application/octet-stream)
 - `--hash-algorithm`: The hash algorithm to use (SHA256, SHA384, SHA512, default: SHA256)
 - `--signature-version`: The indirect signature version (CoseHashEnvelope, default: CoseHashEnvelope)
+- `--payload-location`: A URI indicating where the payload can be retrieved from (optional, CoseHashEnvelope format only). This is useful when the payload is stored at a known location and you want to include that reference in the signature per [RFC 9054](https://datatracker.ietf.org/doc/rfc9054/).
 
 **Universal Logging Options** (available for all plugin commands):
 - `--verbose`, `-v`: Enable verbose logging output (detailed diagnostic information)
@@ -101,6 +102,10 @@ CoseSignTool indirect-sign --payload myfile.txt --signature myfile.cose --pfx my
   --cwt-audience "production-systems" \
   --cwt-claims "exp:2025-06-30T23:59:59Z" \
   --cwt-claims "100:build-metadata"
+
+# Include payload location reference in signature (for remote payload retrieval)
+CoseSignTool indirect-sign --payload myfile.txt --signature myfile.cose --pfx mycert.pfx \
+  --payload-location "https://artifacts.example.com/releases/v1.0/myfile.txt"
 
 # Disable SCITT compliance
 CoseSignTool indirect-sign --payload myfile.txt --signature myfile.cose --pfx mycert.pfx --enable-scitt false

--- a/docs/SCITTCompliance.md
+++ b/docs/SCITTCompliance.md
@@ -375,6 +375,25 @@ CoseSignTool indirect-sign \
   --cwt-claims "exp:2025-12-31T23:59:59Z"
 ```
 
+### Payload Location (RFC 9054)
+
+When using indirect signatures with the CoseHashEnvelope format, you can optionally include a **payload location** URI. This header (label 260, per [RFC 9054](https://datatracker.ietf.org/doc/rfc9054/)) indicates where the original payload can be retrieved from, enabling verification scenarios where the payload is stored separately from the signature.
+
+```bash
+# Include payload location for remote retrieval
+CoseSignTool indirect-sign \
+  --payload artifact.bin \
+  --signature artifact.cose \
+  --pfx mycert.pfx \
+  --cwt-subject "artifact.release.v2.1" \
+  --payload-location "https://artifacts.example.com/releases/v2.1/artifact.bin"
+```
+
+The payload location is stored in the COSE protected headers alongside other Hash Envelope headers:
+- **Label 258**: Payload Hash Algorithm (e.g., SHA-256)
+- **Label 259**: Preimage Content Type (e.g., application/octet-stream)
+- **Label 260**: Payload Location (optional URI)
+
 ## Validation and Reading CWT Claims
 
 When validating signatures, CoseHandler automatically validates the CWT Claims structure. To read the claims:


### PR DESCRIPTION
- Add payloadLocation parameter to IndirectSignatureFactory methods
- Add --payload-location CLI option to IndirectSignCommand
- Wire payload location through CoseHashEnvelopeHeaderExtender (label 260 per RFC 9054)
- Add tests for payload location in both factory and plugin tests
- Update IndirectSignaturePlugin.md documentation
- Update SCITTCompliance.md with Payload Location section

closes #157 