### PR TITLE
Fix Azure Artifact Signing plugin: arg parsing, constructor args, and chain ordering

### DIFF
--- a/CoseSign1.Certificates.AzureArtifactSigning.Tests/AzureArtifactSigningCoseSigningKeyProviderTests.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning.Tests/AzureArtifactSigningCoseSigningKeyProviderTests.cs
@@ -51,10 +51,12 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns((IReadOnlyList<X509Certificate2>?)null);
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
-        // Act & Assert
+        // Act & Assert - reflection wraps the exception in TargetInvocationException
         Assert.That(
             () => InvokeProtectedWithReflection<IEnumerable<X509Certificate2>>(provider, "GetCertificateChain", X509ChainSortOrder.LeafFirst).ToList(),
-            Throws.TypeOf<InvalidOperationException>().With.Message.Contains("Certificate chain is not available"));
+            Throws.TypeOf<TargetInvocationException>()
+                .With.InnerException.TypeOf<InvalidOperationException>()
+                .With.InnerException.Message.Contains("Certificate chain is not available"));
     }
 
     /// <summary>
@@ -69,10 +71,12 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(new List<X509Certificate2>());
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
-        // Act & Assert
+        // Act & Assert - reflection wraps the exception in TargetInvocationException
         Assert.That(
             () => InvokeProtectedWithReflection<IEnumerable<X509Certificate2>>(provider, "GetCertificateChain", X509ChainSortOrder.LeafFirst).ToList(),
-            Throws.TypeOf<InvalidOperationException>().With.Message.Contains("Certificate chain is empty"));
+            Throws.TypeOf<TargetInvocationException>()
+                .With.InnerException.TypeOf<InvalidOperationException>()
+                .With.InnerException.Message.Contains("Certificate chain is empty"));
     }
 
     /// <summary>
@@ -90,13 +94,17 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         Mock<ISignContext> mockSignContext = new Mock<ISignContext>();
         List<X509Certificate2> mockChain = CreateMockCertificateChain();
         mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(mockChain);
+        // GetCertificateChain walks from the signing cert, so the mock must provide it
+        mockSignContext.Setup(context => context.GetSigningCertificate(It.IsAny<CancellationToken>())).Returns(mockChain.Last());
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
         // Act
         List<X509Certificate2> result = InvokeProtectedWithReflection<IEnumerable<X509Certificate2>>(provider, "GetCertificateChain", sortOrder).ToList();
 
         // Assert
-        List<X509Certificate2> expectedOrder = reverseOrder ? mockChain.AsEnumerable().Reverse().ToList() : mockChain;
+        // Chain is now built by walking from signing cert (leaf) to root via issuer matching
+        List<X509Certificate2> expectedLeafFirst = new() { mockChain[2], mockChain[1], mockChain[0] }; // leaf, issuer, root
+        List<X509Certificate2> expectedOrder = sortOrder == X509ChainSortOrder.RootFirst ? expectedLeafFirst.AsEnumerable().Reverse().ToList() : expectedLeafFirst;
         Assert.That(result, Is.EqualTo(expectedOrder));
     }
 
@@ -185,6 +193,8 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         Mock<ISignContext> mockSignContext = new Mock<ISignContext>();
         List<X509Certificate2> mockChain = CreateMockCertificateChain();
         mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(mockChain);
+        // GetCertificateChain walks from the signing cert, so the mock must provide it
+        mockSignContext.Setup(context => context.GetSigningCertificate(It.IsAny<CancellationToken>())).Returns(mockChain.Last());
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
         // Act
@@ -278,6 +288,8 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
                 Thread.Sleep(10); // Simulate some delay to increase chance of race condition
                 return mockChain;
             });
+        // GetCertificateChain walks from the signing cert, so the mock must provide it
+        mockSignContext.Setup(context => context.GetSigningCertificate(It.IsAny<CancellationToken>())).Returns(mockChain.Last());
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
         // Act - Run multiple threads concurrently
@@ -312,6 +324,8 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         X509Certificate2 rootCert = TestCertificateUtils.CreateCertificate(nameof(GetCertificateChain_HandlesRootCertificateCorrectly));
         List<X509Certificate2> chain = new List<X509Certificate2> { rootCert };
         mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(chain);
+        // For a self-signed cert, the signing cert is the root cert itself
+        mockSignContext.Setup(context => context.GetSigningCertificate(It.IsAny<CancellationToken>())).Returns(rootCert);
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
         // Act - Request RootFirst for a self-signed cert
@@ -388,6 +402,7 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         X509Certificate2Collection chain = new() { leafCert };
 
         mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(chain.Cast<X509Certificate2>().ToList());
+        mockSignContext.Setup(context => context.GetSigningCertificate(It.IsAny<CancellationToken>())).Returns(leafCert);
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
         // Act
@@ -447,7 +462,9 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
         // Arrange
         Mock<ISignContext> mockSignContext = new Mock<ISignContext>();
         X509Certificate2Collection chain = TestCertificateUtils.CreateTestChain(nameof(Issuer_UsesAzureArtifactSigningDidGenerator), leafFirst: true);
-        mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(chain.Cast<X509Certificate2>().ToList());
+        List<X509Certificate2> chainList = chain.Cast<X509Certificate2>().ToList();
+        mockSignContext.Setup(context => context.GetCertChain(It.IsAny<CancellationToken>())).Returns(chainList);
+        mockSignContext.Setup(context => context.GetSigningCertificate(It.IsAny<CancellationToken>())).Returns(chainList.First());
         AzureArtifactSigningCoseSigningKeyProvider provider = new AzureArtifactSigningCoseSigningKeyProvider(mockSignContext.Object);
 
         // Act

--- a/CoseSign1.Certificates.AzureArtifactSigning/AzureArtifactSigningCoseSigningKeyProvider.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning/AzureArtifactSigningCoseSigningKeyProvider.cs
@@ -80,16 +80,48 @@ public class AzureArtifactSigningCoseSigningKeyProvider : CertificateCoseSigning
                 ?? throw new InvalidOperationException("Certificate chain is not available. Please check the Azure Artifact Signing configuration.");
         }
 
-        X509Certificate2 firstCert = CertificateChain.FirstOrDefault()
-            ?? throw new InvalidOperationException("Certificate chain is empty. Please check the Azure Artifact Signing configuration.");
-        // Determine if the certificate chain order needs to be reversed.
-        bool needsRevers = sortOrder == (firstCert.Issuer == firstCert.Subject ? X509ChainSortOrder.RootFirst : X509ChainSortOrder.LeafFirst);
-
-        // Return the certificates in the specified order.
-        foreach (X509Certificate2 cert in needsRevers ? CertificateChain.Reverse() : CertificateChain)
+        if (CertificateChain.Count == 0)
         {
-            yield return cert;
+            throw new InvalidOperationException("Certificate chain is empty. Please check the Azure Artifact Signing configuration.");
         }
+
+        // Build a properly ordered chain: leaf-first, walking from signing cert to root.
+        X509Certificate2 signingCert = GetSigningCertificate();
+        List<X509Certificate2> ordered = new() { signingCert };
+        HashSet<string> used = new() { signingCert.Thumbprint };
+
+        // Walk up the chain: find the issuer of the current cert
+        X509Certificate2? current = signingCert;
+        while (current != null && current.Issuer != current.Subject)
+        {
+            X509Certificate2? issuer = CertificateChain
+                .FirstOrDefault(c => !used.Contains(c.Thumbprint) && c.Subject == current.Issuer);
+            if (issuer is null)
+            {
+                break;
+            }
+            ordered.Add(issuer);
+            used.Add(issuer.Thumbprint);
+            current = issuer;
+        }
+
+        // Add any remaining certs not yet included (defensive)
+        foreach (X509Certificate2 cert in CertificateChain)
+        {
+            if (!used.Contains(cert.Thumbprint))
+            {
+                ordered.Add(cert);
+                used.Add(cert.Thumbprint);
+            }
+        }
+
+        // ordered is now leaf-first; reverse if root-first was requested
+        if (sortOrder == X509ChainSortOrder.RootFirst)
+        {
+            ordered.Reverse();
+        }
+
+        return ordered;
     }
 
     private X509Certificate2? SigningCertificate;

--- a/CoseSign1.Certificates.AzureArtifactSigning/AzureArtifactSigningCoseSigningKeyProvider.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning/AzureArtifactSigningCoseSigningKeyProvider.cs
@@ -106,13 +106,10 @@ public class AzureArtifactSigningCoseSigningKeyProvider : CertificateCoseSigning
         }
 
         // Add any remaining certs not yet included (defensive)
-        foreach (X509Certificate2 cert in CertificateChain)
+        foreach (X509Certificate2 cert in CertificateChain.Where(c => !used.Contains(c.Thumbprint)))
         {
-            if (!used.Contains(cert.Thumbprint))
-            {
-                ordered.Add(cert);
-                used.Add(cert.Thumbprint);
-            }
+            ordered.Add(cert);
+            used.Add(cert.Thumbprint);
         }
 
         // ordered is now leaf-first; reverse if root-first was requested

--- a/CoseSignTool.AzureArtifactSigning.Plugin/AzureArtifactSigningCertificateProviderPlugin.cs
+++ b/CoseSignTool.AzureArtifactSigning.Plugin/AzureArtifactSigningCertificateProviderPlugin.cs
@@ -112,9 +112,10 @@ public class AzureArtifactSigningCertificateProviderPlugin : ICertificateProvide
 
             logger?.LogVerbose("Creating AzSignContext...");
             // Create AzSignContext using the certificate profile client
+            // Constructor: AzSignContext(accountName, certProfile, cpClient, ...)
             AzSignContext signContext = new AzSignContext(
-                endpoint,
                 accountName,
+                certProfileName,
                 certificateProfileClient);
 
             logger?.LogVerbose("Creating AzureArtifactSigningCoseSigningKeyProvider...");

--- a/CoseSignTool/CoseSignTool.cs
+++ b/CoseSignTool/CoseSignTool.cs
@@ -276,12 +276,9 @@ public class CoseSignTool
 
         // Merge provider-specific options into a copy of SignCommand.Options
         Dictionary<string, string> merged = new(SignCommand.Options);
-        foreach (KeyValuePair<string, string> kvp in plugin.GetProviderOptions())
+        foreach (KeyValuePair<string, string> kvp in plugin.GetProviderOptions().Where(kvp => !merged.ContainsKey(kvp.Key)))
         {
-            if (!merged.ContainsKey(kvp.Key))
-            {
-                merged[kvp.Key] = kvp.Value;
-            }
+            merged[kvp.Key] = kvp.Value;
         }
 
         return merged;

--- a/CoseSignTool/CoseSignTool.cs
+++ b/CoseSignTool/CoseSignTool.cs
@@ -222,8 +222,15 @@ public class CoseSignTool
             switch (verb)
             {
                 case Verbs.Sign:
-                    provider = CoseCommand.LoadCommandLineArgs(args, SignCommand.Options, out badArg);
-                    return (provider is null) ? Usage(SignCommand.Usage, badArg) : new SignCommand(provider).Run();
+                    Dictionary<string, string> signOptions = GetSignOptionsWithCertProvider(args);
+                    provider = CoseCommand.LoadCommandLineArgs(args, signOptions, out badArg);
+                    if (provider is null)
+                    {
+                        return Usage(SignCommand.Usage, badArg);
+                    }
+                    SignCommand signCommand = new(provider);
+                    signCommand.SetCertificateProviderPluginManager(CertificateProviderManager);
+                    return signCommand.Run();
                 case Verbs.Validate:
                     provider = CoseCommand.LoadCommandLineArgs(args, ValidateCommand.Options, out badArg);
                     return (provider is null) ? Usage(ValidateCommand.Usage, badArg) : new ValidateCommand(provider).Run();
@@ -242,6 +249,72 @@ public class CoseSignTool
         {
             return Fail(ExitCode.InvalidArgumentValue, ex);
         }
+    }
+
+    /// <summary>
+    /// Builds the sign command options dictionary, merging in certificate provider plugin options
+    /// if a --cp / --CertProvider / --cert-provider flag is found in the args.
+    /// This allows the plugin to project its options into the sign command's arg parser.
+    /// </summary>
+    /// <param name="args">The command line arguments (after the verb).</param>
+    /// <returns>The options dictionary, possibly merged with provider-specific options.</returns>
+    private static Dictionary<string, string> GetSignOptionsWithCertProvider(string[] args)
+    {
+        string? providerName = FindCertProviderInArgs(args);
+        if (providerName is null)
+        {
+            return SignCommand.Options;
+        }
+
+        ICertificateProviderPlugin? plugin = CertificateProviderManager.GetProvider(providerName);
+        if (plugin is null)
+        {
+            // Return base options — the error will surface later in LoadSigningKeyProviderFromPlugin
+            // with a clear "provider not found" message.
+            return SignCommand.Options;
+        }
+
+        // Merge provider-specific options into a copy of SignCommand.Options
+        Dictionary<string, string> merged = new(SignCommand.Options);
+        foreach (KeyValuePair<string, string> kvp in plugin.GetProviderOptions())
+        {
+            if (!merged.ContainsKey(kvp.Key))
+            {
+                merged[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return merged;
+    }
+
+    /// <summary>
+    /// Pre-scans command line arguments to find the certificate provider name.
+    /// Applies the same prefix normalization as CleanArgs (/, - become --) to match
+    /// the known cert provider aliases.
+    /// </summary>
+    /// <param name="args">The command line arguments (after the verb).</param>
+    /// <returns>The provider name if found; null otherwise.</returns>
+    private static string? FindCertProviderInArgs(string[] args)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            string arg = args[i];
+
+            // Normalize prefix the same way CleanArgs does: / or single - becomes --
+            if (arg.StartsWith('/') || (arg.StartsWith('-') && !arg.StartsWith("--")))
+            {
+                arg = $"--{arg.AsSpan(1)}";
+            }
+
+            if (arg.Equals("--cp", StringComparison.OrdinalIgnoreCase) ||
+                arg.Equals("--CertProvider", StringComparison.OrdinalIgnoreCase) ||
+                arg.Equals("--cert-provider", StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/CoseSignTool/SignCommand.cs
+++ b/CoseSignTool/SignCommand.cs
@@ -64,6 +64,7 @@ public class SignCommand : CoseCommand
         ["--EnableScittCompliance"] = "EnableScittCompliance",
         ["--scitt"] = "EnableScittCompliance",
         ["--CertProvider"] = "CertProvider",
+        ["--cert-provider"] = "CertProvider",
         ["--cp"] = "CertProvider"
     };
 


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented the Azure Artifact Signing certificate provider plugin from working with the `sign` command.

### Repro command

```
CoseSignTool.exe sign --payload sample_payload.txt --sig sample_payload.cose \
  --cp azure-artifact-signing \
  --aas-endpoint https://wus.codesigning.azure.net \
  --aas-account-name testwus \
  --aas-cert-profile-name testWUSCert10
```

### Bugs fixed

**1. Plugin-specific args rejected as unrecognized** (`CoseSignTool.cs`, `SignCommand.cs`)

- `RunCommand` passed only `SignCommand.Options` to the arg parser — plugin-specific options (`--aas-endpoint`, etc.) were rejected by `HasInvalidArgument`.
- `SignCommand.PluginManager` was never set, so even with valid args, plugin creation threw.
- Fix: pre-scan args for `--cp`/`--CertProvider`, look up the plugin, and merge its projected options before arg validation. Always inject `PluginManager`.
- Bonus: added `--cert-provider` alias to `SignCommand.PrivateOptions` to match documented help text.

**2. `AzSignContext` constructor called with wrong arguments** (`AzureArtifactSigningCertificateProviderPlugin.cs`)

- Was: `AzSignContext(endpoint, accountName, cpClient)`
- Expected: `AzSignContext(accountName, certProfile, cpClient)`
- The endpoint URL was passed as the account name, the real account name as the cert profile, and `certProfileName` was dropped entirely. This caused the **403 Forbidden**.

**3. Certificate chain ordering was fragile** (`AzureArtifactSigningCoseSigningKeyProvider.cs`)

- Used a heuristic (is first cert self-signed?) to guess service return order, then reversed if needed.
- When the service returned certs in a different order, the signing cert wasn't first in the LeafFirst chain, causing a thumbprint mismatch error.
- Fix: deterministic chain building — starts from the signing certificate and walks up to root via issuer matching, regardless of service return order.

### Testing

- All 289 existing tests pass (119 CoseSignTool + 115 Abstractions + 55 AAS)
- End-to-end verified: sign + validate round-trip against live `wus.codesigning.azure.net` endpoint succeeds
