### PR TITLE
Fix parameter passing and certificate chain logic for artifact signing plugin

### DIFF
--- a/CoseSign1.Certificates.AzureArtifactSigning.Tests/AzureArtifactSigningCoseSigningKeyProviderTests.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning.Tests/AzureArtifactSigningCoseSigningKeyProviderTests.cs
@@ -82,8 +82,10 @@ public class AzureArtifactSigningCoseSigningKeyProviderTests
     /// <param name="sortOrder">The desired sort order of the certificate chain.</param>
     /// <param name="reverseOrder">Indicates whether the chain should be reversed.</param>
     [Test]
-    [TestCase(X509ChainSortOrder.LeafFirst, false, TestName = "GetCertificateChain_ReturnsChainInLeafFirstOrder")]
-    [TestCase(X509ChainSortOrder.RootFirst, true, TestName = "GetCertificateChain_ReturnsChainInRootFirstOrder")]
+    // CreateMockCertificateChain() returns the chain in natural (root-first) order: [root, issuer, leaf].
+    // Requesting LeafFirst should reverse it; requesting RootFirst should leave it as-is.
+    [TestCase(X509ChainSortOrder.LeafFirst, true, TestName = "GetCertificateChain_ReturnsChainInLeafFirstOrder")]
+    [TestCase(X509ChainSortOrder.RootFirst, false, TestName = "GetCertificateChain_ReturnsChainInRootFirstOrder")]
     public void GetCertificateChain_ReturnsChainInCorrectOrder(X509ChainSortOrder sortOrder, bool reverseOrder)
     {
         // Arrange

--- a/CoseSign1.Certificates.AzureArtifactSigning/AzureArtifactSigningCoseSigningKeyProvider.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning/AzureArtifactSigningCoseSigningKeyProvider.cs
@@ -83,7 +83,7 @@ public class AzureArtifactSigningCoseSigningKeyProvider : CertificateCoseSigning
         X509Certificate2 firstCert = CertificateChain.FirstOrDefault()
             ?? throw new InvalidOperationException("Certificate chain is empty. Please check the Azure Artifact Signing configuration.");
         // Determine if the certificate chain order needs to be reversed.
-        bool needsRevers = sortOrder == (firstCert.Issuer == firstCert.Subject ? X509ChainSortOrder.RootFirst : X509ChainSortOrder.LeafFirst);
+        bool needsRevers = sortOrder != (firstCert.Issuer == firstCert.Subject ? X509ChainSortOrder.RootFirst : X509ChainSortOrder.LeafFirst);
 
         // Return the certificates in the specified order.
         foreach (X509Certificate2 cert in needsRevers ? CertificateChain.Reverse() : CertificateChain)

--- a/CoseSignTool.AzureArtifactSigning.Plugin/AzureArtifactSigningCertificateProviderPlugin.cs
+++ b/CoseSignTool.AzureArtifactSigning.Plugin/AzureArtifactSigningCertificateProviderPlugin.cs
@@ -88,6 +88,7 @@ public class AzureArtifactSigningCertificateProviderPlugin : ICertificateProvide
             logger?.LogVerbose($"  Account: {accountName}");
             logger?.LogVerbose($"  Certificate Profile: {certProfileName}");
 
+
             // Create Azure credential using DefaultAzureCredential
             // This supports multiple authentication methods in order of precedence:
             // 1. Environment variables (AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, etc.)
@@ -113,8 +114,8 @@ public class AzureArtifactSigningCertificateProviderPlugin : ICertificateProvide
             logger?.LogVerbose("Creating AzSignContext...");
             // Create AzSignContext using the certificate profile client
             AzSignContext signContext = new AzSignContext(
-                endpoint,
                 accountName,
+                certProfileName,
                 certificateProfileClient);
 
             logger?.LogVerbose("Creating AzureArtifactSigningCoseSigningKeyProvider...");


### PR DESCRIPTION
This PR fixes 2 bugs on the usage of the artifact signing plugin. 

- The first one, is a bug on the order of the parameters being passed to the az sign context.
- The second bug, is related to the logic for verification of the certificate chain return.

I've included my local tool showing success for signing and verification:

<img width="1764" height="231" alt="image" src="https://github.com/user-attachments/assets/cde9f464-55e3-4cc3-9745-b2db35949ea8" />
