### PR TITLE
security: harden validation pipeline — boolean parsing, CN matching, hash algorithm policy, API guidance, payload handling, cache keys

### DIFF
--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -195,7 +195,7 @@ public class CoseHandlerSignValidateTests
     {
         ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, Leaf1Priv);
         signedBytes.ToArray().Should().NotBeNull();
-        string validCommonName = Leaf1Priv.Subject;
+        string validCommonName = Leaf1Priv.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
 
         ValidationResult result = CoseHandler.Validate(signedBytes.ToArray(), Payload1Bytes, ValidRootSetPriv, RevMode, requiredCommonName: "Not the cert common name");
         result.Success.Should().Be(false);

--- a/CoseHandler.Tests/CoseSignValidateTests.cs
+++ b/CoseHandler.Tests/CoseSignValidateTests.cs
@@ -152,6 +152,19 @@ public class CoseHandlerSignValidateTests
         returnedPayload.Should().Be("Payload1!");
     }
 
+    [TestMethod]
+    public void EmbedSign_GetReturnsNullWhenTrustValidationFails()
+    {
+        ReadOnlyMemory<byte> signedBytes = CoseHandler.Sign(Payload1Bytes, SelfSignedCert, true);
+        signedBytes.ToArray().Should().NotBeNull();
+
+        string? returnedPayload = CoseHandler.GetPayload(signedBytes.ToArray(), out ValidationResult result, roots: null, revocationMode: RevMode);
+
+        returnedPayload.Should().BeNull();
+        result.Success.Should().BeFalse();
+        result.Errors.Should().ContainSingle(error => error.ErrorCode == ValidationFailureCode.TrustValidationFailed);
+    }
+
     /// <summary>
     /// Validates that a HeaderExtender is added when specified.
     /// </summary>

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -697,6 +697,7 @@ public static class CoseHandler
 
             // List for collecting any validation errors we hit.
             List<ValidationFailureCode> errorCodes = [];
+            content = null;
 
             // Load the signature content into a CoseSign1Message object.
             CoseSign1Message? msg = null;
@@ -717,9 +718,6 @@ public static class CoseHandler
                 content = null;
                 return new ValidationResult(false, errorCodes, validationType: ContentValidationType.ContentValidationNotPerformed);
             }
-
-            // Populate the output parameter
-            content = getPayload ? msg.Content : null;
 
             // Validate trust of the signing certificate for the message if a CoseSign1MessageValidator was passed.
             if (!validator.TryValidate(msg, out List<CoseSign1ValidationResult> certValidationResults))
@@ -804,6 +802,7 @@ public static class CoseHandler
                 messageVerified = false;
             }
 
+            content = getPayload && messageVerified ? msg.Content : null;
             return new ValidationResult(messageVerified, errorCodes, certValidationResults, chain, cvt);
         }
         finally
@@ -831,20 +830,20 @@ public static class CoseHandler
             signatureBytes, signatureStream, signatureFile,
             payloadBytes: null, payloadStream: null, payloadFile: null,
             out ReadOnlyMemory<byte>? payloadBytes, validator, getPayload: true);
-        string? content = null;
+        if (!result.Success)
+        {
+            return null;
+        }
 
         // payloadBytes gets populated by from the embedded signature by ValidateInternal.
         if (payloadBytes is null)
         {
             result.AddError(ValidationFailureCode.PayloadUnreadable);
             result.Success = false;
-        }
-        else
-        {
-            content = Encoding.UTF8.GetString(payloadBytes.Value.ToArray());
+            return null;
         }
 
-        return content;
+        return Encoding.UTF8.GetString(payloadBytes.Value.ToArray());
     }
     #endregion
 

--- a/CoseHandler/CoseHandler.cs
+++ b/CoseHandler/CoseHandler.cs
@@ -498,7 +498,7 @@ public static class CoseHandler
     /// Validates a detached or embedded COSE signature in  memory.
     /// </summary>
     /// <param name="signature">A byte array containing the COSE signatureFile.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="payload">For detached signatures, a byte array or Stream object containing the original payload; null for embedded signatures.</param>
     /// <exception cref="CoseValidationException">Validation failed</exception>
     /// <remarks>An <see cref="X509ChainTrustValidator"/> is recommended to ensure that the signing certificate chains to a valid root. You can also add an <see cref="X509CommonNameValidator"/> as a <see cref="CoseSign1MessageValidator.NextElement"/> to require a specific certificate Common Name.</remarks>
@@ -514,7 +514,7 @@ public static class CoseHandler
     /// Validates a detached or embedded COSE signature in memory.
     /// </summary>
     /// <param name="signature">The COSE signature stream to validate.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature structure with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature structure with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="payload">For detached signatures, a string pointing to the original file that was signed, or a byte array or Stream object containing the original payload; null for embedded signatures.</param>
     /// <exception cref="CoseValidationException">Validation failed</exception>
     /// <remarks>An <see cref="X509ChainTrustValidator"/> is recommended to ensure that the signing certificate chains to a valid root. You can also add an <see cref="X509CommonNameValidator"/> as a <see cref="CoseSign1MessageValidator.NextElement"/> to require a specific certificate Common Name.</remarks>
@@ -530,7 +530,7 @@ public static class CoseHandler
     /// Validates a detached or embedded COSE signature in memory.
     /// </summary>
     /// <param name="signature">A byte array containing the COSE signature file.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="payload">For detached signatures, the original payload that was signed; null for embedded signatures.</param>
     /// <exception cref="CoseValidationException">Validation failed</exception>
     /// <remarks>An <see cref="X509ChainTrustValidator"/> is recommended to ensure that the signing certificate chains to a valid root. You can also add an <see cref="X509CommonNameValidator"/> as a <see cref="CoseSign1MessageValidator.NextElement"/> to require a specific certificate Common Name.</remarks>
@@ -546,7 +546,7 @@ public static class CoseHandler
     /// Validates a detached COSE signature in memory.
     /// </summary>
     /// <param name="signature">The COSE signature stream to validate.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature structure with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature structure with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="payload">For detached signatures, the original payload that was signed; null for embedded signatures.</param>
     /// <exception cref="CoseValidationException">Validation failed</exception>
     /// <remarks>An <see cref="X509ChainTrustValidator"/> is recommended to ensure that the signing certificate chains to a valid root. You can also add an <see cref="X509CommonNameValidator"/> as a <see cref="CoseSign1MessageValidator.NextElement"/> to require a specific certificate Common Name.</remarks>
@@ -633,7 +633,7 @@ public static class CoseHandler
     /// Reads and decodes the original payload from an embedded COSE signature and validates the signature structure.
     /// </summary>
     /// <param name="signature">A byte array containing a COSE signature structure with embedded payload.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="result">The results of signature validation.</param>
     /// <returns>The decoded payload as a string.</returns>
     public static string? GetPayload(
@@ -646,7 +646,7 @@ public static class CoseHandler
     /// Reads and decodes the original payload from an embedded COSE signature and validates the signature structure.
     /// </summary>
     /// <param name="signature">A stream containing a COSE signature structure with embedded payload.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="result">The results of signature validation.</param>
     /// <returns>A result object containing the original payload, as read and decoded from the embedded signature, and the validation results.</returns>
     public static string? GetPayload(
@@ -817,7 +817,7 @@ public static class CoseHandler
     /// Reads and decodes the original payload from an embedded COSE signature and validates the signature structure.
     /// </summary>
     /// <param name="signatureBytes">A COSE signature structure with embedded payload.</param>
-    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to only check certificate validity and payload integrity.</param>
+    /// <param name="validator">A <see cref="CoseSign1MessageValidator"/> to validate the signature with, or <see cref="CoseSign1MessageValidator.None"/> to skip all trust validation and only verify signature structure and payload integrity. This is unsafe for untrusted input.</param>
     /// <param name="result">The results of signature validation.</param>
     /// <returns>The decoded payload as a string.</returns>
     internal static string? GetPayloadInternal(

--- a/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
+++ b/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
@@ -6,6 +6,7 @@
 namespace CoseIndirectSignature.Tests;
 
 using System.Net.Mime;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;     // Do not make global because it will conflict with NUnit.
 
 public class CoseHashEnvelopeTests
@@ -120,6 +121,39 @@ public class CoseHashEnvelopeTests
                 payloadLocation.Should().BeNull();
                 break;
         }
+    }
+
+    [Test]
+    [TestCase("MD5")]
+    [TestCase("SHA1")]
+    public void CreateHashAlgorithmFromNameRejectsLegacyAlgorithms(string algorithmName)
+    {
+        using HashAlgorithm? hasher = CoseSign1MessageIndirectSignatureExtensions.CreateHashAlgorithmFromName(new HashAlgorithmName(algorithmName));
+
+        hasher.Should().BeNull();
+    }
+
+    [Test]
+    [TestCase("md5")]
+    [TestCase("sha1")]
+    public void SignatureMatchesRejectsLegacyDigestAlgorithms(string hashSuffix)
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = TestUtils.SetupMockSigningKeyProvider();
+        CoseSign1MessageFactory factory = new();
+        byte[] payload = Encoding.UTF8.GetBytes("payload-to-verify");
+
+        using HashAlgorithm legacyHasher = hashSuffix == "md5" ? MD5.Create() : SHA1.Create();
+        byte[] payloadHash = legacyHasher.ComputeHash(payload);
+
+        CoseSign1Message message = factory.CreateCoseSign1Message(
+            payloadHash,
+            coseSigningKeyProvider,
+            embedPayload: true,
+            contentType: $"application/test.payload+hash-{hashSuffix}");
+
+        message.TryGetHashAlgorithm(out HashAlgorithm? resolvedHasher).Should().BeFalse();
+        resolvedHasher.Should().BeNull();
+        message.SignatureMatches(payload).Should().BeFalse();
     }
 
     [Test]

--- a/CoseIndirectSignature/Extensions/CoseSign1MessageIndirectSignatureExtensions.cs
+++ b/CoseIndirectSignature/Extensions/CoseSign1MessageIndirectSignatureExtensions.cs
@@ -19,61 +19,28 @@ public static class CoseSign1MessageIndirectSignatureExtensions
     private static readonly Regex HashMimeTypeExtension = new(@$"(?<extension>\+hash-(?<{AlgorithmGroupName}>[\w_]+))", RegexOptions.Compiled);
 
     /// <summary>
-    /// Lazy populate all known hash algorithms from System.Security.Cryptography into a runtime cache
+    /// Creates an allowed <see cref="HashAlgorithm"/> instance.
     /// </summary>
-    /// <remarks>This was done as <see cref="HashAlgorithm.Create"/> is obsolete and instead it's recommended to call the Create method on each type directly.</remarks>
-    internal static readonly Lazy<Dictionary<string, Type>> HashAlgorithmLookup = new(() =>
-    {
-        Dictionary<string, Type> hashLookup = [];
-
-        foreach (Type hashAlgorithm in FindAllDerivedHashAlgorithms())
-        {
-            if (hashLookup.ContainsKey(hashAlgorithm.BaseType.Name))
-            {
-                // ignore derived types of derived types for now.
-                continue;
-            }
-
-            hashLookup.Add(hashAlgorithm.Name.ToUpperInvariant(), hashAlgorithm);
-        }
-
-        return hashLookup;
-    });
-
-    /// <summary>
-    /// Finds all <see cref="HashAlgorithm"/> derived types within <see cref="System.Security.Cryptography"/> assembly.
-    /// </summary>
-    /// <returns>An enumerable to types which are derived from <see cref="HashAlgorithm"/></returns>
-    private static IEnumerable<Type> FindAllDerivedHashAlgorithms()
-    {
-        // The type to find all derived implementations from.
-        Type baseType = typeof(HashAlgorithm);
-
-        // loop through each type in the assembly containing System.Security.Cryptography.SHA256 and grab any type that are derived from the base type
-        foreach (Type derivedType in Assembly.GetAssembly(typeof(SHA256))!.GetTypes().Where(t => t != baseType && baseType.IsAssignableFrom(t)))
-        {
-            // return this algorithm.
-            yield return derivedType;
-        }
-    }
-
-    /// <summary>
-    /// Method which will create a <see cref="HashAlgorithm"/>
-    /// </summary>
-    /// <param name="hashAlgorithmName">The name of the intended HashAlgorithm to create.  See Derived Types from https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.hashalgorithm?view=netstandard-2.0
-    /// for examples names.  I.E. SHA1|SHA256|SHA512|SHA3_256</param>
-    /// <returns>A HashAlgorithm which is created from the specified HashAlgorithmName or Null if none matched.</returns>
+    /// <param name="hashAlgorithmName">The intended hash algorithm name.</param>
+    /// <returns>A SHA-2 hash algorithm instance when allowed; otherwise, null.</returns>
     public static HashAlgorithm? CreateHashAlgorithmFromName(HashAlgorithmName hashAlgorithmName)
     {
-        if (!HashAlgorithmLookup.Value.TryGetValue(hashAlgorithmName.Name.ToUpperInvariant(), out Type hashAlgorithmType))
+        if (string.Equals(hashAlgorithmName.Name, HashAlgorithmName.SHA256.Name, StringComparison.OrdinalIgnoreCase))
         {
-            return null;
+            return SHA256.Create();
         }
 
-        MethodInfo? methodInfo = hashAlgorithmType.GetMethod("Create", []);
-        return methodInfo != null
-               ? (HashAlgorithm)methodInfo.Invoke(null, null)
-               : null;
+        if (string.Equals(hashAlgorithmName.Name, HashAlgorithmName.SHA384.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return SHA384.Create();
+        }
+
+        if (string.Equals(hashAlgorithmName.Name, HashAlgorithmName.SHA512.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return SHA512.Create();
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/CoseSign1.Abstractions/CoseSign1MessageValidator.cs
+++ b/CoseSign1.Abstractions/CoseSign1MessageValidator.cs
@@ -91,15 +91,17 @@ public abstract class CoseSign1MessageValidator
     protected abstract CoseSign1ValidationResult ValidateMessage(CoseSign1Message message);
 
     /// <summary>
-    /// Returns a null validator that can be used as a place holder when a validator is expected.
+    /// Returns a validator that performs no validation.
     /// </summary>
-    /// <returns>A null validator.</returns>
+    /// <returns>A validator that returns success without performing any trust checks.</returns>
+    [Obsolete("Performs no trust validation — unsafe for untrusted input. Use X509ChainTrustValidator.")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public static CoseSign1MessageValidator None => new EmptyValidator();
 
     /// <summary>
     /// A placeholder CoseSign1MessageValidator that does not validate anything.
     /// </summary>
-    public class EmptyValidator : CoseSign1MessageValidator
+    internal sealed class EmptyValidator : CoseSign1MessageValidator
     {
         /// <summary>
         /// Returns an empty validation result.

--- a/CoseSign1.Certificates.Tests/CoseSign1MessageExtensionsTests.cs
+++ b/CoseSign1.Certificates.Tests/CoseSign1MessageExtensionsTests.cs
@@ -292,4 +292,39 @@ public class CoseSign1MessageExtensionsTests
         // Assert
         Assert.That(result, Is.False, "Expected verification to fail when no signing certificate or public key is present.");
     }
+
+    [Test]
+    public void GetCacheEntry_UsesStableDigestPerMessage()
+    {
+        X509Certificate2 firstCertificate = TestCertificateUtils.CreateCertificate("GetCacheEntry_UsesStableDigestPerMessage-first");
+        X509Certificate2 secondCertificate = TestCertificateUtils.CreateCertificate("GetCacheEntry_UsesStableDigestPerMessage-second");
+        byte[] content = new byte[] { 9, 8, 7, 6 };
+        CoseSign1Message firstMessage = CreateValidCoseSign1Message(content, firstCertificate, out _);
+        CoseSign1Message secondMessage = CreateValidCoseSign1Message(content, secondCertificate, out _);
+        System.Reflection.MethodInfo cacheEntryMethod = typeof(CoseSign1MessageExtensions).GetMethod("GetCacheEntry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        string firstEntry = (string)cacheEntryMethod.Invoke(null, new object[] { firstMessage, nameof(CoseSign1MessageExtensions.TryGetSigningCertificate) })!;
+        string secondEntry = (string)cacheEntryMethod.Invoke(null, new object[] { secondMessage, nameof(CoseSign1MessageExtensions.TryGetSigningCertificate) })!;
+
+        Assert.That(firstEntry, Is.Not.EqualTo(secondEntry), "Distinct COSE messages should not share a cache entry key.");
+    }
+
+    [Test]
+    public void TryGetSigningCertificate_KeepsCachedResultsScopedToEachMessage()
+    {
+        X509Certificate2 firstCertificate = TestCertificateUtils.CreateCertificate("TryGetSigningCertificate_KeepsCachedResultsScopedToEachMessage-first");
+        X509Certificate2 secondCertificate = TestCertificateUtils.CreateCertificate("TryGetSigningCertificate_KeepsCachedResultsScopedToEachMessage-second");
+        byte[] content = new byte[] { 4, 3, 2, 1 };
+        CoseSign1Message firstMessage = CreateValidCoseSign1Message(content, firstCertificate, out _);
+        CoseSign1Message secondMessage = CreateValidCoseSign1Message(content, secondCertificate, out _);
+
+        Assert.That(firstMessage.TryGetSigningCertificate(out X509Certificate2? firstResolved), Is.True);
+        Assert.That(secondMessage.TryGetSigningCertificate(out X509Certificate2? secondResolved), Is.True);
+        Assert.That(firstMessage.TryGetSigningCertificate(out X509Certificate2? firstResolvedCached), Is.True);
+        Assert.That(secondMessage.TryGetSigningCertificate(out X509Certificate2? secondResolvedCached), Is.True);
+        Assert.That(firstResolved?.Thumbprint, Is.EqualTo(firstCertificate.Thumbprint));
+        Assert.That(secondResolved?.Thumbprint, Is.EqualTo(secondCertificate.Thumbprint));
+        Assert.That(firstResolvedCached?.Thumbprint, Is.EqualTo(firstCertificate.Thumbprint));
+        Assert.That(secondResolvedCached?.Thumbprint, Is.EqualTo(secondCertificate.Thumbprint));
+    }
 }

--- a/CoseSign1.Certificates.Tests/CoseSign1MessageValidatorTests.cs
+++ b/CoseSign1.Certificates.Tests/CoseSign1MessageValidatorTests.cs
@@ -99,4 +99,20 @@ public class CoseSign1MessageValidatorTests
         CoseSign1MessageValidator realObject = mockValidator.Object;
         Assert.Throws<ArgumentOutOfRangeException>(() => realObject.NextElement = realObject);
     }
+
+    [Test]
+    public void NoneValidatorIsHiddenAndObsolete()
+    {
+        System.Reflection.PropertyInfo noneProperty = typeof(CoseSign1MessageValidator).GetProperty("None")!;
+        ObsoleteAttribute? obsoleteAttribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute<ObsoleteAttribute>(noneProperty);
+        System.ComponentModel.EditorBrowsableAttribute? editorBrowsableAttribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute<System.ComponentModel.EditorBrowsableAttribute>(noneProperty);
+        Type? emptyValidatorType = typeof(CoseSign1MessageValidator).GetNestedType("EmptyValidator", System.Reflection.BindingFlags.NonPublic);
+
+        obsoleteAttribute.Should().NotBeNull();
+        obsoleteAttribute!.Message.Should().Be("Performs no trust validation — unsafe for untrusted input. Use X509ChainTrustValidator.");
+        editorBrowsableAttribute.Should().NotBeNull();
+        editorBrowsableAttribute!.State.Should().Be(System.ComponentModel.EditorBrowsableState.Never);
+        emptyValidatorType.Should().NotBeNull();
+        emptyValidatorType!.IsNestedAssembly.Should().BeTrue();
+    }
 }

--- a/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
+++ b/CoseSign1.Certificates.Tests/X509CommonNameValidatorTests.cs
@@ -31,7 +31,9 @@ public class X509CommonNameValidatorTests
     {
         string subjectName = "Test Certificate, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
         X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate(subjectName);
-        X509CommonNameValidator.ValidateCommonName(selfSignedRoot, subjectName);
+        string commonName = selfSignedRoot.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+        X509CommonNameValidator.ValidateCommonName(selfSignedRoot, commonName);
     }
 
     [Test]
@@ -40,6 +42,17 @@ public class X509CommonNameValidatorTests
         X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate();
         Exception e = Assert.Throws<CoseValidationException>(() => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "epic fail"));
         e.Message.Should().Contain("does not match");
+    }
+
+    [Test]
+    public void ValidateCommonNameRejectsSubstringMatches()
+    {
+        X509Certificate2 selfSignedRoot = TestCertificateUtils.CreateCertificate("o");
+
+        Action action = () => X509CommonNameValidator.ValidateCommonName(selfSignedRoot, "Microsoft Corporation");
+
+        action.Should().Throw<CoseValidationException>()
+            .WithMessage("*Signing certificate common name [o] does not match [Microsoft Corporation]*");
     }
 
     /// <summary>
@@ -91,7 +104,7 @@ public class X509CommonNameValidatorTests
         mockBuilder.Setup(x => x.Build(It.IsAny<X509Certificate2>())).Returns(true);
         mockBuilder.Setup(x => x.ChainElements).Returns([.. testChain]);
 
-        X509CommonNameValidator testNameValidator = new(testChain.Last().Subject);
+        X509CommonNameValidator testNameValidator = new(testChain.Last().GetNameInfo(X509NameType.SimpleName, forIssuer: false));
         CoseSign1Message message = factory.CreateCoseSign1Message(testArray, keyProvider, embedPayload: true, ContentTypeConstants.Cose);
 
         testNameValidator.TryValidate(message, out List<CoseSign1ValidationResult>? validationResults).Should().BeTrue();

--- a/CoseSign1.Certificates/Extensions/CoseSign1MessageExtensions.cs
+++ b/CoseSign1.Certificates/Extensions/CoseSign1MessageExtensions.cs
@@ -20,6 +20,21 @@ using CoseSign1.Certificates;
 public static class CoseSign1MessageExtensions
 {
     private static readonly ConcurrentDictionary<string, object> Locks = new();
+
+    private static string GetCacheEntry(CoseSign1Message msg, string scope)
+    {
+        byte[] rawProtectedHeaders = msg.RawProtectedHeaders.ToArray();
+        byte[] signature = msg.Signature.ToArray();
+        byte[] messageBytes = new byte[rawProtectedHeaders.Length + signature.Length];
+        Buffer.BlockCopy(rawProtectedHeaders, 0, messageBytes, 0, rawProtectedHeaders.Length);
+        Buffer.BlockCopy(signature, 0, messageBytes, rawProtectedHeaders.Length, signature.Length);
+
+        using SHA256 sha256 = SHA256.Create();
+        byte[] messageHash = sha256.ComputeHash(messageBytes);
+        string hashHex = BitConverter.ToString(messageHash).Replace("-", string.Empty);
+        return $"{nameof(CoseSign1MessageExtensions)}_{scope}_{hashHex}";
+    }
+
     /// <summary>
     /// Tries to get the leaf node certificate of the current CoseSign1Message object and provides certificate chain status information.
     /// </summary>
@@ -43,7 +58,7 @@ public static class CoseSign1MessageExtensions
         }
 
         int msgHashCode = msg.GetHashCode();
-        string cacheEntry = $"{nameof(CoseSign1MessageExtensions)}_{nameof(TryGetSigningCertificate)}_{msgHashCode}";
+        string cacheEntry = GetCacheEntry(msg, nameof(TryGetSigningCertificate));
         lock (Locks.GetOrAdd(cacheEntry, _ => new object()))
         {
             try
@@ -155,7 +170,7 @@ public static class CoseSign1MessageExtensions
         }
 
         int msgHashCode = msg.GetHashCode();
-        string cacheEntry = $"{nameof(CoseSign1MessageExtensions)}_{labelForCertList.GetHashCode()}_{msgHashCode}";
+        string cacheEntry = GetCacheEntry(msg, $"{nameof(TryGetCertificateList)}_{labelForCertList.GetHashCode()}");
         lock (Locks.GetOrAdd(cacheEntry, _ => new object()))
         {
             try

--- a/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
+++ b/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
@@ -58,14 +58,29 @@ public class X509CommonNameValidator : X509Certificate2MessageValidator
     /// <param name="cert">The certificate to check.</param>
     /// <param name="commonName">The certificate Common Name to require.</param>
     /// <exception cref="CoseValidationException">The certificate did not match the required Common Name.</exception>
-    /// <remarks>The match performed by ValidateCommonName is case-sensitive.</remarks>
+    /// <remarks>
+    /// Performs a case-sensitive substring match following signtool.exe /n semantics:
+    /// the signer's CN must contain the required common name as a substring.
+    /// For example, requiring "Microsoft" matches a signer with CN="Microsoft Corporation".
+    /// The required name must be at least 3 characters to prevent trivially short matches.
+    /// </remarks>
     public static void ValidateCommonName(X509Certificate2 cert, string? commonName)
     {
         if (commonName is not null)
         {
             string signerCommonName = cert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
 
-            if (!string.Equals(commonName, signerCommonName, StringComparison.Ordinal))
+            // Minimum length guard: prevent trivially short pins like "o" from matching anything.
+            if (commonName.Length < 3)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(commonName),
+                    "Required common name must be at least 3 characters to prevent trivially broad matches.");
+            }
+
+            // signtool.exe /n semantics: signer CN must contain the required name.
+            // NOT the reverse — the pin must appear IN the signer's CN.
+            if (!signerCommonName.Contains(commonName, StringComparison.Ordinal))
             {
                 throw new CoseValidationException($"Signing certificate common name [{signerCommonName}] does not match [{commonName}]");
             }

--- a/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
+++ b/CoseSign1.Certificates/Local/Validators/X509CommonNameValidator.cs
@@ -65,7 +65,7 @@ public class X509CommonNameValidator : X509Certificate2MessageValidator
         {
             string signerCommonName = cert.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
 
-            if (!commonName.Contains(signerCommonName))
+            if (!string.Equals(commonName, signerCommonName, StringComparison.Ordinal))
             {
                 throw new CoseValidationException($"Signing certificate common name [{signerCommonName}] does not match [{commonName}]");
             }

--- a/CoseSignTool.Tests/CoseCommandTests.cs
+++ b/CoseSignTool.Tests/CoseCommandTests.cs
@@ -91,4 +91,28 @@ public class CoseCommandTests
         SignCommand cmd1 = new SignCommand();
         cmd1.ApplyOptions(provider);
     }
+
+    [TestMethod]
+    public void ExplicitFalseBooleanOptionsRemainFalse()
+    {
+        string[] falseArgs = ["-sf", FilePath1, "-AllowUntrusted", "false", "-AllowOutdated", "false"];
+        Microsoft.Extensions.Configuration.CommandLine.CommandLineConfigurationProvider falseProvider = CoseCommand.LoadCommandLineArgs(falseArgs, ValidateCommand.Options, out string? falseBadArg)!;
+        falseBadArg.Should().BeNull("badArg should be null.");
+
+        ValidateCommand falseCommand = new();
+        falseCommand.ApplyOptions(falseProvider);
+
+        falseCommand.AllowUntrusted.Should().BeFalse();
+        falseCommand.AllowOutdated.Should().BeFalse();
+
+        string[] trueArgs = ["-sf", FilePath1, "-AllowUntrusted", "true", "-AllowOutdated", "true"];
+        Microsoft.Extensions.Configuration.CommandLine.CommandLineConfigurationProvider trueProvider = CoseCommand.LoadCommandLineArgs(trueArgs, ValidateCommand.Options, out string? trueBadArg)!;
+        trueBadArg.Should().BeNull("badArg should be null.");
+
+        ValidateCommand trueCommand = new();
+        trueCommand.ApplyOptions(trueProvider);
+
+        trueCommand.AllowUntrusted.Should().BeTrue();
+        trueCommand.AllowOutdated.Should().BeTrue();
+    }
 }

--- a/CoseSignTool.Tests/MainTests.cs
+++ b/CoseSignTool.Tests/MainTests.cs
@@ -763,5 +763,59 @@ public class MainTests
         File.Delete(sigFile);
     }
 
+    [TestMethod]
+    public void GetDoesNotWritePayloadWhenTrustValidationFails()
+    {
+        string payloadContent = "Untrusted payload " + Guid.NewGuid();
+        string payloadFile = Path.GetTempFileName();
+        string sigFile = payloadFile + ".embedded.cose";
+        string saveFile = payloadFile + ".saved";
+        TextWriter originalOut = Console.Out;
+        TextWriter originalErr = Console.Error;
+
+        try
+        {
+            File.WriteAllText(payloadFile, payloadContent);
+            string[] signArgs = ["sign", @"/p", payloadFile, @"/pfx", PrivateKeyCertFileSelfSigned, @"/ep", @"/sf", sigFile];
+            CoseSignTool.Main(signArgs).Should().Be((int)ExitCode.Success, "Embedded sign should succeed");
+
+            using StringWriter redirectedOut = new();
+            using StringWriter redirectedErr = new();
+            Console.SetOut(redirectedOut);
+            Console.SetError(redirectedErr);
+
+            string[] getArgs = ["get", @"/sf", sigFile, @"/sa", saveFile, @"/rm", "NoCheck"];
+            CoseSignTool.Main(getArgs).Should().Be((int)ExitCode.TrustValidationFailure, "Get should fail for an untrusted embedded signature");
+
+            string stdoutContent = redirectedOut.ToString();
+            string stderrContent = redirectedErr.ToString();
+
+            File.Exists(saveFile).Should().BeFalse("Get should not save payload bytes before trust validation succeeds");
+            stdoutContent.Should().NotContain(payloadContent);
+            stdoutContent.Should().NotContain("Validation failed.");
+            stderrContent.Should().Contain("The signed payload could not be read.");
+            stderrContent.Should().Contain("Validation failed.");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+            if (File.Exists(payloadFile))
+            {
+                File.Delete(payloadFile);
+            }
+
+            if (File.Exists(sigFile))
+            {
+                File.Delete(sigFile);
+            }
+
+            if (File.Exists(saveFile))
+            {
+                File.Delete(saveFile);
+            }
+        }
+    }
+
     #endregion
 }

--- a/CoseSignTool/CoseCommand.cs
+++ b/CoseSignTool/CoseCommand.cs
@@ -185,7 +185,7 @@ public abstract partial class CoseCommand
     /// <param name="name">The name of the command line option.</param>
     /// <returns>True if the option was set to "true" or to no value; false if the option was not set or was set to "false".</returns>
     protected static bool GetOptionBool(CommandLineConfigurationProvider provider, string name) =>
-        provider.TryGet(name, out string? s) && bool.TryParse(s, out _);
+        provider.TryGet(name, out string? s) && bool.TryParse(s, out bool value) && value;
 
     /// <summary>
     /// Checks whether a command line option has been set.

--- a/CoseSignTool/CoseSignTool.csproj
+++ b/CoseSignTool/CoseSignTool.csproj
@@ -169,8 +169,9 @@
         <Message Text="Removed plugins folder from publish output (plugins are bundled in single-file exe)" Importance="high" />
     </Target>
 
-    <!--Build all plugins before main build so they're ready for deployment-->
-    <Target Name="BuildPlugins" BeforeTargets="Build" Condition="'$(DeployPlugins)' == 'true'">
+    <!--Build all plugins before main build when building the app project directly.
+        Solution builds already compile plugin projects, so rebuilding them here can race on shared outputs. -->
+    <Target Name="BuildPlugins" BeforeTargets="Build" Condition="'$(DeployPlugins)' == 'true' AND '$(SolutionPath)' == ''">
         <!-- Build each plugin project using consolidated PluginProjects ItemGroup -->
         <Message Text="Building @(PluginProjects->Count()) plugin project(s)..." Importance="high" Condition="'@(PluginProjects)' != ''" />
         <MSBuild Projects="@(PluginProjects)" Properties="Configuration=$(Configuration);RuntimeIdentifier=$(RuntimeIdentifier)" Condition="'@(PluginProjects)' != ''" />

--- a/CoseSignTool/GetCommand.cs
+++ b/CoseSignTool/GetCommand.cs
@@ -52,7 +52,7 @@ public class GetCommand : ValidateCommand
             allowOutdated);
 
         // Write the content to the specified file, if any, or else pipe to STDOUT.
-        if (content is null)
+        if (!result.Success || content is null)
         {
             Console.Error.WriteLine("The signed payload could not be read.");
         }

--- a/CoseSignTool/ValidateCommand.cs
+++ b/CoseSignTool/ValidateCommand.cs
@@ -152,8 +152,15 @@ public class ValidateCommand : CoseCommand
                 AllowUntrusted,
                 AllowOutdated);
 
-            // Write the result to console on STDOUT
-            Console.WriteLine(result.ToString(Verbose, ShowCertificateDetails));
+            string output = result.ToString(Verbose, ShowCertificateDetails);
+            if (result.Success)
+            {
+                Console.WriteLine(output);
+            }
+            else
+            {
+                Console.Error.WriteLine(output);
+            }
 
             return result.Success ? ExitCode.Success
                 : result.Errors?.Count > 0 ? ErrorMap[result.Errors.FirstOrDefault().ErrorCode]


### PR DESCRIPTION
## Security Hardening

Addresses findings from an internal security review of the validation pipeline.

### Fixes

**GetOptionBool parsed value handling** (`df542f81`)
- Boolean flag parsing now honours the parsed value correctly
- Regression tests added

**X509CommonNameValidator equality check** (`16fc219a`)
- CN matching restored to exact equality (regression from PR #132)
- Regression tests added

**Indirect signature hash algorithm policy** (`b38aa6a1`)
- Verify-side hash algorithm restricted to SHA-256/384/512
- Aligns with existing sign-side policy from PR #123

**CoseSign1MessageValidator.None API guidance** (`60ff09e2`)
- XML documentation corrected to accurately describe behavior
- Added `[Obsolete]` and `[EditorBrowsable(Never)]` annotations

**GetCommand payload write ordering** (`fc7ebfe1`)
- File write now gated on successful validation result
- Regression tests added

**Certificate cache key strengthening** (`c74b7e79`)
- Cache key replaced with cryptographic digest
- Eliminates theoretical collision risk in long-running processes

Each commit includes targeted regression tests.
