### PR TITLE
Fix MST anonymous auth + plugin ALC type identity, add AAS perf parity

### DIFF
--- a/CoseSign1.Abstractions/Interfaces/ISupportsScittCompliance.cs
+++ b/CoseSign1.Abstractions/Interfaces/ISupportsScittCompliance.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseSign1.Abstractions.Interfaces;
+
+/// <summary>
+/// Optional capability interface implemented by <see cref="ICoseSigningKeyProvider"/> implementations
+/// that support toggling SCITT (Supply Chain Integrity, Transparency, and Trust) compliance behavior.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Hosts that need to enable or disable automatic CWT (CBOR Web Token) claim emission on a
+/// signing-key provider should test for this interface rather than depending on a specific concrete
+/// type. This keeps the cross-boundary contract in <c>CoseSign1.Abstractions</c>, allowing
+/// implementing assemblies (e.g. <c>CoseSign1.Certificates</c>) to remain plugin-local in
+/// host/plugin <see cref="System.Runtime.Loader.AssemblyLoadContext"/> isolation scenarios without
+/// triggering type-identity mismatches.
+/// </para>
+/// <para>
+/// Example host pattern:
+/// <code>
+/// ICoseSigningKeyProvider provider = plugin.CreateProvider(configuration);
+/// if (provider is ISupportsScittCompliance scittProvider)
+/// {
+///     scittProvider.EnableScittCompliance = enableScittCompliance;
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+public interface ISupportsScittCompliance
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether SCITT-compliant CWT claims (issuer and subject) are
+    /// automatically added to signatures produced by this provider.
+    /// </summary>
+    /// <remarks>
+    /// Implementations should default this to <c>true</c> when SCITT compliance is the expected
+    /// behavior for the provider. Setting to <c>false</c> suppresses default-claim emission;
+    /// user-supplied CWT claims attached via header extenders remain unaffected.
+    /// </remarks>
+    bool EnableScittCompliance { get; set; }
+}

--- a/CoseSign1.Certificates.AzureArtifactSigning.Tests/AasClientOptionsExtensionsTests.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning.Tests/AasClientOptionsExtensionsTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace CoseSign1.Certificates.AzureArtifactSigning.Tests;
+
+using System;
+using Azure.CodeSigning;
+using Azure.Core;
+using Azure.Developer.ArtifactSigning.CryptoProvider.Models;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for <see cref="AasClientOptionsExtensions"/> — the AAS analogue of the MST
+/// performance optimisation extensions. These verify that interactive signing latency
+/// is bounded by short, fixed-delay retries and that callers can override defaults
+/// without losing fluent chaining.
+/// </summary>
+[TestFixture]
+public class AasClientOptionsExtensionsTests
+{
+    [Test]
+    public void ConfigureAasPerformanceOptimizations_AppliesFastFixedRetries()
+    {
+        // Arrange
+        CertificateProfileClientOptions options = new CertificateProfileClientOptions();
+
+        // Act
+        CertificateProfileClientOptions returned = options.ConfigureAasPerformanceOptimizations();
+
+        // Assert
+        Assert.That(returned, Is.SameAs(options), "Extension method must return the same instance for fluent chaining.");
+        Assert.That(options.Retry.Mode, Is.EqualTo(RetryMode.Fixed), "Retry mode must be Fixed for predictable interactive latency.");
+        Assert.That(options.Retry.Delay, Is.EqualTo(AasClientOptionsExtensions.DefaultRetryDelay));
+        Assert.That(options.Retry.MaxRetries, Is.EqualTo(AasClientOptionsExtensions.DefaultMaxRetries));
+    }
+
+    [Test]
+    public void ConfigureAasPerformanceOptimizations_HonoursOverrides()
+    {
+        // Arrange
+        CertificateProfileClientOptions options = new CertificateProfileClientOptions();
+        TimeSpan customDelay = TimeSpan.FromMilliseconds(100);
+        const int customRetries = 16;
+
+        // Act
+        options.ConfigureAasPerformanceOptimizations(customDelay, customRetries);
+
+        // Assert
+        Assert.That(options.Retry.Delay, Is.EqualTo(customDelay));
+        Assert.That(options.Retry.MaxRetries, Is.EqualTo(customRetries));
+    }
+
+    [Test]
+    public void ConfigureAasPerformanceOptimizations_NullOptions_Throws()
+    {
+        // Act / Assert
+        ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
+            () => AasClientOptionsExtensions.ConfigureAasPerformanceOptimizations(null!));
+        Assert.That(ex.ParamName, Is.EqualTo("options"));
+    }
+
+    [Test]
+    public void ConfigureAasSigningPerformance_ReturnsDefaultsWhenUnset()
+    {
+        // Act
+        AzSignContextOptions opts = AasClientOptionsExtensions.ConfigureAasSigningPerformance();
+
+        // Assert
+        Assert.That(opts, Is.Not.Null);
+        Assert.That(opts.TaskRetryCount, Is.EqualTo(AasClientOptionsExtensions.DefaultSigningTaskRetryCount));
+        Assert.That(opts.TaskTimeOutInSeconds, Is.EqualTo(AasClientOptionsExtensions.DefaultSigningTaskTimeoutSeconds));
+    }
+
+    [Test]
+    public void ConfigureAasSigningPerformance_HonoursOverrides()
+    {
+        // Act
+        AzSignContextOptions opts = AasClientOptionsExtensions.ConfigureAasSigningPerformance(
+            taskRetryCount: 5,
+            taskTimeoutSeconds: 30);
+
+        // Assert
+        Assert.That(opts.TaskRetryCount, Is.EqualTo(5));
+        Assert.That(opts.TaskTimeOutInSeconds, Is.EqualTo(30));
+    }
+}

--- a/CoseSign1.Certificates.AzureArtifactSigning/Extensions/AasClientOptionsExtensions.cs
+++ b/CoseSign1.Certificates.AzureArtifactSigning/Extensions/AasClientOptionsExtensions.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.CodeSigning;
+
+using System;
+using Azure.Core;
+using Azure.Developer.ArtifactSigning.CryptoProvider.Models;
+
+/// <summary>
+/// Extension methods for tuning the Azure Artifact Signing (AAS) client pipeline and signing-context
+/// timing knobs for improved interactive signing performance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Azure SDK's default <see cref="RetryOptions"/> use exponential back-off starting at 800 ms with
+/// 3 retries (≈ 5 s before giving up). For interactive signing scenarios — where a user is waiting at
+/// a console — that can stretch a transient blip into a multi-second wait. These extensions apply
+/// fixed-delay 250 ms retries with up to 8 attempts so the typical recovery window is short, while
+/// leaving the <c>AzSignContext</c> long-running signing operation knobs
+/// (<see cref="AzSignContextOptions"/>) adjustable via <see cref="ConfigureAasSigningPerformance"/>.
+/// </para>
+/// <para>
+/// <b>Retry-After honoured.</b> Azure.Core's <c>RetryPolicy</c> always honours a server-supplied
+/// <c>Retry-After</c> header even when <see cref="RetryMode.Fixed"/> is configured. If AAS asks the
+/// client to back off (e.g. <c>Retry-After: 30</c>), that value wins over the configured 250 ms delay,
+/// so the practical worst-case latency is bounded by the server's policy, not the SDK ceiling. This is
+/// intentional: AAS uses <c>Retry-After</c> correctly and the client should respect it. Unlike the MST
+/// equivalent (<c>MstClientOptionsExtensions.ConfigureMstPerformanceOptimizations</c>) this helper does
+/// <b>not</b> strip <c>Retry-After</c> headers — that is an MST-specific work-around for the Code
+/// Transparency Service's eventual-consistency window where the server returns optimistic 1-second
+/// hints that the client can safely beat.
+/// </para>
+/// </remarks>
+public static class AasClientOptionsExtensions
+{
+    /// <summary>
+    /// The default interval between fast retry attempts when the server does not supply
+    /// <c>Retry-After</c>. A server-supplied value will override this.
+    /// </summary>
+    public static readonly TimeSpan DefaultRetryDelay = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// The default maximum number of fast retry attempts. With no <c>Retry-After</c> back-pressure
+    /// the worst-case ceiling is approximately <c>MaxRetries * DefaultRetryDelay</c> (≈ 2 seconds).
+    /// </summary>
+    public const int DefaultMaxRetries = 8;
+
+    /// <summary>
+    /// The default <see cref="AzSignContextOptions.TaskRetryCount"/> applied by
+    /// <see cref="ConfigureAasSigningPerformance"/>. Matches the SDK default; surfaced as a constant
+    /// so callers can tune relative to a known baseline.
+    /// </summary>
+    public const int DefaultSigningTaskRetryCount = 3;
+
+    /// <summary>
+    /// The default <see cref="AzSignContextOptions.TaskTimeOutInSeconds"/> applied by
+    /// <see cref="ConfigureAasSigningPerformance"/>. Matches the SDK default.
+    /// </summary>
+    public const int DefaultSigningTaskTimeoutSeconds = 60;
+
+    /// <summary>
+    /// Configures the Azure SDK retry pipeline on a <see cref="CertificateProfileClientOptions"/>
+    /// instance to use a short fixed delay between retries so transient certificate-profile lookups
+    /// do not stretch interactive signing latency. Server-supplied <c>Retry-After</c> values are
+    /// still honoured and override the configured delay.
+    /// </summary>
+    /// <param name="options">The <see cref="CertificateProfileClientOptions"/> to configure.</param>
+    /// <param name="retryDelay">
+    /// Interval between fast retry attempts. Defaults to <see cref="DefaultRetryDelay"/> (250 ms).
+    /// </param>
+    /// <param name="maxRetries">
+    /// Maximum number of fast retry attempts before failing. Defaults to <see cref="DefaultMaxRetries"/> (8).
+    /// </param>
+    /// <returns>The same <paramref name="options"/> instance for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// CertificateProfileClientOptions options = new CertificateProfileClientOptions();
+    /// options.ConfigureAasPerformanceOptimizations();
+    /// CertificateProfileClient client = new CertificateProfileClient(credential, endpoint, options);
+    /// </code>
+    /// </example>
+    public static CertificateProfileClientOptions ConfigureAasPerformanceOptimizations(
+        this CertificateProfileClientOptions options,
+        TimeSpan? retryDelay = null,
+        int? maxRetries = null)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        options.Retry.Mode = RetryMode.Fixed;
+        options.Retry.Delay = retryDelay ?? DefaultRetryDelay;
+        options.Retry.MaxRetries = maxRetries ?? DefaultMaxRetries;
+
+        return options;
+    }
+
+    /// <summary>
+    /// Builds an <see cref="AzSignContextOptions"/> instance with the supplied long-running signing
+    /// timing knobs, falling back to the SDK defaults when a value is not specified.
+    /// </summary>
+    /// <param name="taskRetryCount">
+    /// Maximum number of times the signing task is retried before failing. Defaults to
+    /// <see cref="DefaultSigningTaskRetryCount"/>.
+    /// </param>
+    /// <param name="taskTimeoutSeconds">
+    /// Per-task timeout in seconds for the signing long-running operation. Defaults to
+    /// <see cref="DefaultSigningTaskTimeoutSeconds"/>.
+    /// </param>
+    /// <returns>A populated <see cref="AzSignContextOptions"/>.</returns>
+    /// <example>
+    /// <code>
+    /// AzSignContextOptions opts = AasClientOptionsExtensions.ConfigureAasSigningPerformance(
+    ///     taskRetryCount: 5,
+    ///     taskTimeoutSeconds: 30);
+    /// AzSignContext signContext = new AzSignContext(account, profile, client, null, opts);
+    /// </code>
+    /// </example>
+    public static AzSignContextOptions ConfigureAasSigningPerformance(
+        int? taskRetryCount = null,
+        int? taskTimeoutSeconds = null)
+    {
+        return new AzSignContextOptions
+        {
+            TaskRetryCount = taskRetryCount ?? DefaultSigningTaskRetryCount,
+            TaskTimeOutInSeconds = taskTimeoutSeconds ?? DefaultSigningTaskTimeoutSeconds
+        };
+    }
+}

--- a/CoseSign1.Certificates.Tests/CertificateCoseSigningKeyProviderEnableScittTests.cs
+++ b/CoseSign1.Certificates.Tests/CertificateCoseSigningKeyProviderEnableScittTests.cs
@@ -116,4 +116,62 @@ public class CertificateCoseSigningKeyProviderEnableScittTests
         claims!.Issuer.Should().NotBeNull();
         claims.Subject.Should().Be(CwtClaims.DefaultSubject);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="CertificateCoseSigningKeyProvider"/> implements the shared
+    /// <see cref="ISupportsScittCompliance"/> capability interface from
+    /// <c>CoseSign1.Abstractions</c>. This is the cross-AssemblyLoadContext contract that lets
+    /// the host toggle SCITT compliance on plugin-returned providers without referencing the
+    /// concrete provider type — keeping <c>CoseSign1.Certificates</c> plugin-local.
+    /// </summary>
+    [Test]
+    public void TestImplementsISupportsScittCompliance_ContractDefinedInAbstractions()
+    {
+        // Arrange
+        X509Certificate2 cert = TestCertificateUtils.CreateCertificate();
+        ICertificateChainBuilder chainBuilder = new TestChainBuilder();
+        ICoseSigningKeyProvider provider = new X509Certificate2CoseSigningKeyProvider(chainBuilder, cert);
+
+        // Act — host pattern: probe via shared capability interface, never via concrete type.
+        bool implementsScittCapability = provider is ISupportsScittCompliance;
+
+        // Assert
+        implementsScittCapability.Should().BeTrue(
+            "CertificateCoseSigningKeyProvider must expose the shared ISupportsScittCompliance capability so the host can toggle SCITT compliance without depending on the concrete type");
+
+        // The capability interface MUST live in CoseSign1.Abstractions so it can be host-shared
+        // across plugin AssemblyLoadContext boundaries. Verifying this stops accidental moves
+        // into a plugin-local assembly.
+        typeof(ISupportsScittCompliance).Assembly.GetName().Name.Should().Be(
+            "CoseSign1.Abstractions",
+            "ISupportsScittCompliance must remain in the host-shared CoseSign1.Abstractions assembly to preserve cross-ALC type identity");
+    }
+
+    /// <summary>
+    /// Verifies the round-trip: setting EnableScittCompliance through the
+    /// <see cref="ISupportsScittCompliance"/> interface flows through to the underlying provider's
+    /// behavior (matching the <c>SignCommand</c> downcast pattern).
+    /// </summary>
+    [Test]
+    public void TestISupportsScittCompliance_RoundTripsThroughInterface()
+    {
+        // Arrange
+        X509Certificate2 cert = TestCertificateUtils.CreateCertificate();
+        ICertificateChainBuilder chainBuilder = new TestChainBuilder();
+        ICoseSigningKeyProvider provider = new X509Certificate2CoseSigningKeyProvider(chainBuilder, cert);
+
+        // Act — exact mirror of SignCommand's host-side pattern after the Phase 3 refactor.
+        if (provider is ISupportsScittCompliance scittProvider)
+        {
+            scittProvider.EnableScittCompliance = false;
+        }
+
+        // Assert — concrete property reflects the interface-driven change.
+        ((CertificateCoseSigningKeyProvider)provider).EnableScittCompliance.Should().BeFalse(
+            "Setting EnableScittCompliance via the shared interface must affect the underlying provider behavior");
+
+        CoseHeaderMap headers = provider.GetProtectedHeaders();
+        headers.ContainsKey(CWTClaimsHeaderLabels.CWTClaims).Should().BeFalse(
+            "Disabling SCITT compliance through the shared interface must suppress default CWT claim emission");
+    }
 }

--- a/CoseSign1.Certificates/CertificateCoseSigningKeyProvider.cs
+++ b/CoseSign1.Certificates/CertificateCoseSigningKeyProvider.cs
@@ -8,7 +8,7 @@ using CoseSign1.Certificates.Extensions;
 /// <summary>
 /// Abstract class which contains common logic needed for all certificate based <see cref="ICoseSigningKeyProvider"/> implementations.
 /// </summary>
-public abstract class CertificateCoseSigningKeyProvider : ICoseSigningKeyProvider
+public abstract class CertificateCoseSigningKeyProvider : ICoseSigningKeyProvider, ISupportsScittCompliance
 {
     private static readonly DidX509Generator DefaultDidGenerator = new();
 

--- a/CoseSignTool.Abstractions.Tests/PluginLoadContextAdvancedTests.cs
+++ b/CoseSignTool.Abstractions.Tests/PluginLoadContextAdvancedTests.cs
@@ -47,29 +47,16 @@ public class PluginLoadContextAdvancedTests
     }
 
     /// <summary>
-    /// Tests IsHostShared with System assemblies.
+    /// Tests IsHostShared with System assemblies. Note: BCL <c>System.*</c> is no longer
+    /// pre-emptively shared — the runtime's default-context fallback handles them via TPA.
+    /// Only the bare <c>System</c> name and the dotted-prefix-less framework families remain
+    /// in the explicit prefix list. This test is retained as a documented contract.
     /// </summary>
     [TestMethod]
-    public void IsHostShared_WithSystemAssemblies_ShouldReturnTrue()
+    public void IsHostShared_WithBareSystemName_ShouldReturnTrue()
     {
-        // Arrange
-        string[] systemAssemblies = {
-            "System",
-            "System.Collections",
-            "System.Collections.Concurrent",
-            "System.IO",
-            "System.Runtime",
-            "System.Text.Json",
-            "System.Threading.Tasks",
-            "System.Reflection.Emit"
-        };
-
-        // Act & Assert
-        foreach (string assemblyName in systemAssemblies)
-        {
-            bool result = PluginLoadContext.IsHostShared(assemblyName);
-            Assert.IsTrue(result, $"'{assemblyName}' should be recognized as a shared framework assembly");
-        }
+        bool result = PluginLoadContext.IsHostShared("System");
+        Assert.IsTrue(result, "Bare 'System' assembly must be host-shared (BCL).");
     }
 
     /// <summary>
@@ -118,12 +105,14 @@ public class PluginLoadContextAdvancedTests
 
     /// <summary>
     /// Tests IsHostShared with bare framework assembly names that need exact matching
-    /// (no trailing dot) to avoid collisions like "netstandardX" or "mscorlibX".
+    /// (no trailing dot) to avoid collisions like "netstandardX" or "mscorlibX". Includes
+    /// bare "System" because the unprefixed System assembly is BCL-only.
     /// </summary>
     [TestMethod]
     public void IsHostShared_WithBareFrameworkNames_ShouldReturnTrue()
     {
         string[] frameworkNames = {
+            "System",
             "netstandard",
             "mscorlib",
             "WindowsBase",
@@ -135,6 +124,39 @@ public class PluginLoadContextAdvancedTests
         {
             bool result = PluginLoadContext.IsHostShared(assemblyName);
             Assert.IsTrue(result, $"'{assemblyName}' is a bare framework name and must be host-shared");
+        }
+    }
+
+    /// <summary>
+    /// Tests that BCL <c>System.*</c> assemblies do NOT match a shared prefix anymore. They
+    /// resolve via the runtime's default-context fallback (TPA) when <c>PluginLoadContext.Load</c>
+    /// returns null, so functional behavior is preserved. The deliberate non-listing here lets
+    /// out-of-band <c>System.*</c> NuGet packages (like <c>System.ClientModel</c>) load
+    /// plugin-locally when shipped alongside a plugin.
+    /// </summary>
+    [TestMethod]
+    public void IsHostShared_WithSystemDotPrefix_ShouldReturnFalse()
+    {
+        string[] systemDotNames = {
+            "System.Collections",
+            "System.Collections.Concurrent",
+            "System.IO",
+            "System.Runtime",
+            "System.Text.Json",
+            "System.Threading.Tasks",
+            "System.Reflection.Emit",
+            // NuGet packages with System.* names that legitimately ship as plugin-private deps:
+            "System.ClientModel",
+            "System.Memory.Data",
+            "System.IO.Pipelines",
+            "System.Diagnostics.DiagnosticSource",
+            "System.Security.Cryptography.ProtectedData",
+        };
+
+        foreach (string assemblyName in systemDotNames)
+        {
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsFalse(result, $"'{assemblyName}' must NOT match a shared prefix — BCL System.* resolves via default-context fallback, NuGet System.* may be plugin-local");
         }
     }
 
@@ -261,9 +283,8 @@ public class PluginLoadContextAdvancedTests
     {
         // Arrange — only assemblies that ARE host-shared after the cleanup
         string[] differentCasingAssemblies = {
-            "system.collections",
-            "SYSTEM.IO",
-            "Microsoft.extensions.logging",
+            "system",                       // bare framework name (exact match, case-insensitive)
+            "Microsoft.extensions.logging", // Microsoft.Extensions.* prefix
             "COSESIGNTOOL.ABSTRACTIONS",
             "cosesign1.abstractions",
             "cosesign1.HEADERS",

--- a/CoseSignTool.Abstractions.Tests/PluginLoadContextAdvancedTests.cs
+++ b/CoseSignTool.Abstractions.Tests/PluginLoadContextAdvancedTests.cs
@@ -47,10 +47,10 @@ public class PluginLoadContextAdvancedTests
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with System assemblies.
+    /// Tests IsHostShared with System assemblies.
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithSystemAssemblies_ShouldReturnTrue()
+    public void IsHostShared_WithSystemAssemblies_ShouldReturnTrue()
     {
         // Arrange
         string[] systemAssemblies = {
@@ -67,17 +67,16 @@ public class PluginLoadContextAdvancedTests
         // Act & Assert
         foreach (string assemblyName in systemAssemblies)
         {
-            AssemblyName name = new AssemblyName(assemblyName);
-            bool result = InvokeIsSharedFrameworkAssembly(name);
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
             Assert.IsTrue(result, $"'{assemblyName}' should be recognized as a shared framework assembly");
         }
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with Microsoft.Extensions assemblies.
+    /// Tests IsHostShared with Microsoft.Extensions assemblies.
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithMicrosoftExtensionsAssemblies_ShouldReturnTrue()
+    public void IsHostShared_WithMicrosoftExtensionsAssemblies_ShouldReturnTrue()
     {
         // Arrange
         string[] extensionsAssemblies = {
@@ -92,62 +91,140 @@ public class PluginLoadContextAdvancedTests
         // Act & Assert
         foreach (string assemblyName in extensionsAssemblies)
         {
-            AssemblyName name = new AssemblyName(assemblyName);
-            bool result = InvokeIsSharedFrameworkAssembly(name);
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
             Assert.IsTrue(result, $"'{assemblyName}' should be recognized as a shared framework assembly");
         }
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with project-specific shared assemblies.
+    /// Tests IsHostShared with the curated cross-boundary contract assemblies.
+    /// These are exact-name matches; the prefix-collision smell is gone.
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithProjectSharedAssemblies_ShouldReturnTrue()
+    public void IsHostShared_WithSharedContractAssemblies_ShouldReturnTrue()
     {
-        // Arrange
-        string[] projectSharedAssemblies = {
+        string[] sharedContracts = {
             "CoseSignTool.Abstractions",
-            "CoseHandler",
-            "CoseSign1",
-            "CoseIndirectSignature"
+            "CoseSign1.Abstractions",
+            "CoseSign1.Headers",
         };
 
-        // Act & Assert
-        foreach (string assemblyName in projectSharedAssemblies)
+        foreach (string assemblyName in sharedContracts)
         {
-            AssemblyName name = new AssemblyName(assemblyName);
-            bool result = InvokeIsSharedFrameworkAssembly(name);
-            Assert.IsTrue(result, $"'{assemblyName}' should be recognized as a project shared assembly");
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsTrue(result, $"'{assemblyName}' is a curated cross-boundary contract and must be host-shared");
         }
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with third-party shared assemblies.
+    /// Tests IsHostShared with bare framework assembly names that need exact matching
+    /// (no trailing dot) to avoid collisions like "netstandardX" or "mscorlibX".
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithThirdPartySharedAssemblies_ShouldReturnTrue()
+    public void IsHostShared_WithBareFrameworkNames_ShouldReturnTrue()
     {
-        // Arrange
-        string[] thirdPartySharedAssemblies = {
-            "Newtonsoft.Json",
+        string[] frameworkNames = {
             "netstandard",
-            "mscorlib"
+            "mscorlib",
+            "WindowsBase",
+            "Microsoft.CSharp",
+            "Microsoft.VisualBasic",
         };
 
-        // Act & Assert
-        foreach (string assemblyName in thirdPartySharedAssemblies)
+        foreach (string assemblyName in frameworkNames)
         {
-            AssemblyName name = new AssemblyName(assemblyName);
-            bool result = InvokeIsSharedFrameworkAssembly(name);
-            Assert.IsTrue(result, $"'{assemblyName}' should be recognized as a shared framework assembly");
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsTrue(result, $"'{assemblyName}' is a bare framework name and must be host-shared");
         }
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with plugin-specific assemblies.
+    /// Tests IsHostShared with assembly names that previously matched the loose "CoseSign1" /
+    /// "CoseHandler" / "CoseIndirectSignature" prefix and would have been silently absorbed into
+    /// the host context. After the prefix removal these are plugin-local.
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithPluginSpecificAssemblies_ShouldReturnFalse()
+    public void IsHostShared_WithFormerlySharedPrefixes_ShouldReturnFalse()
+    {
+        string[] noLongerShared = {
+            "CoseHandler",                                      // host-only static usage now
+            "CoseIndirectSignature",                            // plugin-local
+            "CoseSign1",                                        // plugin-local concrete impl
+            "CoseSign1.Certificates",                           // plugin-local; Phase 3 ISupportsScittCompliance handles cross-boundary
+            "CoseSign1.Transparent.MST",                        // plugin-local; co-located with Azure SDK in plugin ALC
+            "CoseSign1.Certificates.AzureArtifactSigning",      // plugin-local; co-located with Azure SDK in plugin ALC
+        };
+
+        foreach (string assemblyName in noLongerShared)
+        {
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsFalse(result, $"'{assemblyName}' must NOT be host-shared after the prefix-list cleanup — it is plugin-local");
+        }
+    }
+
+    /// <summary>
+    /// Tests that a hypothetical 3rd-party plugin assembly whose name happens to start with
+    /// "CoseSign1" is NOT silently absorbed into the host context. This is the prefix-collision
+    /// regression test that motivated the move to exact-name matching.
+    /// </summary>
+    [TestMethod]
+    public void IsHostShared_WithThirdPartyPrefixCollisions_ShouldReturnFalse()
+    {
+        string[] thirdPartyImpostors = {
+            "CoseSign1Plus",
+            "CoseSign1Extra.Plugin",
+            "CoseHandlerExtensions",
+            "CoseIndirectSignatureV2",
+            "CoseSignTool.Abstractions.Extras", // looks like an extension but is a different assembly
+        };
+
+        foreach (string assemblyName in thirdPartyImpostors)
+        {
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsFalse(result, $"'{assemblyName}' must NOT match the shared list — exact-name only");
+        }
+    }
+
+    /// <summary>
+    /// Tests that Azure SDK assemblies are NOT host-shared. Before Phase 2, these were forced into
+    /// the host context as a workaround for cross-ALC type identity bugs in shared CoseSign1.* libs.
+    /// After Phase 2, those libs are plugin-local, so the SDK types co-locate with their callers
+    /// and never need to cross any boundary.
+    /// </summary>
+    [TestMethod]
+    public void IsHostShared_WithAzureSdkAssemblies_ShouldReturnFalse()
+    {
+        string[] azureSdkAssemblies = {
+            "Azure.Core",
+            "Azure.Identity",
+            "Azure.Security.CodeTransparency",
+            "Azure.CodeSigning",
+            "Azure.Developer.ArtifactSigning",
+            "Azure.Developer.ArtifactSigning.CryptoProvider",
+        };
+
+        foreach (string assemblyName in azureSdkAssemblies)
+        {
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsFalse(result, $"'{assemblyName}' must NOT be host-shared — Azure SDK packages are plugin-local");
+        }
+    }
+
+    /// <summary>
+    /// Tests that Newtonsoft.Json is NOT host-shared. Plugins ship their own copy if they use it.
+    /// </summary>
+    [TestMethod]
+    public void IsHostShared_WithNewtonsoftJson_ShouldReturnFalse()
+    {
+        bool result = PluginLoadContext.IsHostShared("Newtonsoft.Json");
+        Assert.IsFalse(result, "Newtonsoft.Json must NOT be host-shared — it was a leftover prefix that introduced unwanted host coupling");
+    }
+
+    /// <summary>
+    /// Tests IsHostShared with plugin-specific assemblies.
+    /// </summary>
+    [TestMethod]
+    public void IsHostShared_WithPluginSpecificAssemblies_ShouldReturnFalse()
     {
         // Arrange
         string[] pluginSpecificAssemblies = {
@@ -161,50 +238,44 @@ public class PluginLoadContextAdvancedTests
         // Act & Assert
         foreach (string assemblyName in pluginSpecificAssemblies)
         {
-            AssemblyName name = new AssemblyName(assemblyName);
-            bool result = InvokeIsSharedFrameworkAssembly(name);
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
             Assert.IsFalse(result, $"'{assemblyName}' should NOT be recognized as a shared framework assembly");
         }
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with null assembly name.
+    /// Tests IsHostShared with null and empty assembly name.
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithNullAssemblyName_ShouldReturnFalse()
+    public void IsHostShared_WithNullOrEmptyName_ShouldReturnFalse()
     {
-        // Arrange
-        AssemblyName assemblyName = new AssemblyName();
-        // assemblyName.Name will be null
-        
-        // Act
-        bool result = InvokeIsSharedFrameworkAssembly(assemblyName);
-        
-        // Assert
-        Assert.IsFalse(result, "Assembly with null name should return false");
+        Assert.IsFalse(PluginLoadContext.IsHostShared(null), "Null name should return false");
+        Assert.IsFalse(PluginLoadContext.IsHostShared(string.Empty), "Empty name should return false");
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly with case sensitivity.
+    /// Tests IsHostShared with case sensitivity.
     /// </summary>
     [TestMethod]
-    public void IsSharedFrameworkAssembly_WithDifferentCasing_ShouldReturnTrue()
+    public void IsHostShared_WithDifferentCasing_ShouldReturnTrue()
     {
-        // Arrange
+        // Arrange — only assemblies that ARE host-shared after the cleanup
         string[] differentCasingAssemblies = {
             "system.collections",
             "SYSTEM.IO",
             "Microsoft.extensions.logging",
             "COSESIGNTOOL.ABSTRACTIONS",
-            "cosehandler"
+            "cosesign1.abstractions",
+            "cosesign1.HEADERS",
+            "MSCORLIB",
+            "NETSTANDARD"
         };
 
         // Act & Assert
         foreach (string assemblyName in differentCasingAssemblies)
         {
-            AssemblyName name = new AssemblyName(assemblyName);
-            bool result = InvokeIsSharedFrameworkAssembly(name);
-            Assert.IsTrue(result, $"'{assemblyName}' should be recognized as shared framework assembly regardless of casing");
+            bool result = PluginLoadContext.IsHostShared(assemblyName);
+            Assert.IsTrue(result, $"'{assemblyName}' should be recognized as shared regardless of casing");
         }
     }
 
@@ -423,29 +494,6 @@ public class PluginLoadContextAdvancedTests
             object? result = method.Invoke(context, new object[] { unmanagedDllName });
             Assert.IsInstanceOfType(result, typeof(IntPtr), "LoadUnmanagedDll should return IntPtr");
             return (IntPtr)result;
-        }
-        catch (TargetInvocationException ex) when (ex.InnerException != null)
-        {
-            // Re-throw the inner exception to preserve original exception type
-            throw ex.InnerException;
-        }
-    }
-
-    /// <summary>
-    /// Uses reflection to invoke the private IsSharedFrameworkAssembly method.
-    /// </summary>
-    private static bool InvokeIsSharedFrameworkAssembly(AssemblyName assemblyName)
-    {
-        MethodInfo? method = typeof(PluginLoadContext).GetMethod("IsSharedFrameworkAssembly", 
-            BindingFlags.NonPublic | BindingFlags.Static);
-        
-        Assert.IsNotNull(method, "IsSharedFrameworkAssembly method should exist");
-        
-        try
-        {
-            object? result = method.Invoke(null, new object[] { assemblyName });
-            Assert.IsInstanceOfType(result, typeof(bool), "IsSharedFrameworkAssembly should return bool");
-            return (bool)result;
         }
         catch (TargetInvocationException ex) when (ex.InnerException != null)
         {

--- a/CoseSignTool.Abstractions.Tests/PluginLoadContextBasicTests.cs
+++ b/CoseSignTool.Abstractions.Tests/PluginLoadContextBasicTests.cs
@@ -95,7 +95,7 @@ public class PluginLoadContextBasicTests
     }
 
     /// <summary>
-    /// Tests that shared framework assemblies return null to allow default loading.
+    /// Tests that shared framework / curated contract assemblies return null to allow default loading.
     /// </summary>
     [TestMethod]
     public void Load_WithSharedFrameworkAssembly_ShouldReturnNull()
@@ -108,21 +108,20 @@ public class PluginLoadContextBasicTests
         
         try
         {
-            // Test various shared framework assemblies
+            // Test framework assemblies and the curated cross-boundary contract assemblies.
+            // Names like "CoseHandler", "CoseSign1.Certificates", and Azure SDK assemblies are
+            // intentionally NOT host-shared after the prefix-list cleanup — see
+            // PluginLoadContextAdvancedTests for the negative cases.
             string[] sharedAssemblies = {
                 "System.Collections",
                 "Microsoft.Extensions.Logging",
-                "CoseSignTool.Abstractions",
-                "CoseHandler",
                 "System",
-                // Azure SDK assemblies whose types cross the plugin/host boundary via shared
-                // CoseSign1.* helpers (CoseSign1.Transparent.MST + CoseSign1.Certificates.AzureArtifactSigning).
-                // Loading them in the plugin context would create distinct type identities and
-                // produce MissingMethodException at runtime.
-                "Azure.Core",
-                "Azure.Security.CodeTransparency",
-                "Azure.CodeSigning",
-                "Azure.Developer.ArtifactSigning.CryptoProvider"
+                "mscorlib",
+                "netstandard",
+                // Curated cross-boundary contracts:
+                "CoseSignTool.Abstractions",
+                "CoseSign1.Abstractions",
+                "CoseSign1.Headers",
             };
 
             foreach (string assemblyName in sharedAssemblies)

--- a/CoseSignTool.Abstractions.Tests/PluginLoadContextBasicTests.cs
+++ b/CoseSignTool.Abstractions.Tests/PluginLoadContextBasicTests.cs
@@ -114,7 +114,15 @@ public class PluginLoadContextBasicTests
                 "Microsoft.Extensions.Logging",
                 "CoseSignTool.Abstractions",
                 "CoseHandler",
-                "System"
+                "System",
+                // Azure SDK assemblies whose types cross the plugin/host boundary via shared
+                // CoseSign1.* helpers (CoseSign1.Transparent.MST + CoseSign1.Certificates.AzureArtifactSigning).
+                // Loading them in the plugin context would create distinct type identities and
+                // produce MissingMethodException at runtime.
+                "Azure.Core",
+                "Azure.Security.CodeTransparency",
+                "Azure.CodeSigning",
+                "Azure.Developer.ArtifactSigning.CryptoProvider"
             };
 
             foreach (string assemblyName in sharedAssemblies)

--- a/CoseSignTool.Abstractions.Tests/PluginLoadContextIntegrationTests.cs
+++ b/CoseSignTool.Abstractions.Tests/PluginLoadContextIntegrationTests.cs
@@ -125,7 +125,8 @@ public class PluginLoadContextIntegrationTests
     }
 
     /// <summary>
-    /// Tests IsSharedFrameworkAssembly logic with comprehensive framework assembly names.
+    /// Tests that the curated host-shared list (framework + cross-boundary contracts) returns
+    /// null from <see cref="PluginLoadContext.Load"/> so the default ALC handles them.
     /// </summary>
     [TestMethod]
     public void Integration_SharedFrameworkAssemblies_ShouldReturnNullForAllFrameworkTypes()
@@ -138,7 +139,10 @@ public class PluginLoadContextIntegrationTests
         
         try
         {
-            // Test comprehensive list of framework assemblies
+            // Test the curated host-shared set: framework families + repo-owned cross-boundary
+            // contracts. Names like "CoseHandler", "CoseSign1", "CoseIndirectSignature", and
+            // "Newtonsoft.Json" are intentionally excluded from sharing now — they were prefix
+            // matches that introduced unwanted host coupling and prefix-collision risk.
             string[] frameworkAssemblies = {
                 // System assemblies
                 "System",
@@ -149,26 +153,22 @@ public class PluginLoadContextIntegrationTests
                 "System.Text.Json",
                 "System.Threading",
                 "System.Reflection",
-                
+
                 // Microsoft Extensions
                 "Microsoft.Extensions.Logging",
                 "Microsoft.Extensions.DependencyInjection",
                 "Microsoft.Extensions.Configuration",
                 "Microsoft.Extensions.Hosting",
-                
+
                 // Core framework
                 "Microsoft.NETCore.App",
                 "netstandard",
                 "mscorlib",
-                
-                // Third party shared
-                "Newtonsoft.Json",
-                
-                // Project specific shared
+
+                // Curated cross-boundary contracts (exact-name match, no prefix collision risk)
                 "CoseSignTool.Abstractions",
-                "CoseHandler",
-                "CoseSign1",
-                "CoseIndirectSignature"
+                "CoseSign1.Abstractions",
+                "CoseSign1.Headers",
             };
 
             foreach (string assemblyName in frameworkAssemblies)
@@ -179,6 +179,112 @@ public class PluginLoadContextIntegrationTests
                 
                 // Assert
                 Assert.IsNull(result, $"Framework assembly '{assemblyName}' should return null to allow default loading");
+            }
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    /// <summary>
+    /// Regression test for the prefix-collision smell. A plugin-supplied assembly whose name
+    /// starts with a formerly-shared prefix (CoseSign1, CoseHandler, CoseIndirectSignature) MUST
+    /// be loaded plugin-locally — not silently absorbed into the host context.
+    /// </summary>
+    [TestMethod]
+    public void Integration_PrefixCollisionImpostor_LoadsPluginLocallyNotHostShared()
+    {
+        // Arrange
+        string pluginPath = Path.Join(_pluginDirectory, "Main.dll");
+        File.WriteAllText(pluginPath, "main plugin content");
+
+        // Place a stub "CoseSign1Plus.dll" in the plugin directory. With the OLD prefix matching,
+        // the loader would have considered this name shared and skipped the plugin-local probe;
+        // with the NEW exact-name list the plugin-local probe IS attempted (and fails for a stub
+        // file, returning null after a logged warning).
+        string impostorPath = Path.Join(_pluginDirectory, "CoseSign1Plus.dll");
+        File.WriteAllBytes(impostorPath, Encoding.UTF8.GetBytes("MZ"));
+
+        PluginLoadContext context = new PluginLoadContext(pluginPath, _pluginDirectory);
+
+        try
+        {
+            // Act — capture stderr to confirm the plugin-local probe was attempted (proof that
+            // the shared-list short-circuit did NOT consume this name).
+            StringWriter consoleOutput = new StringWriter();
+            TextWriter originalError = Console.Error;
+            Console.SetError(consoleOutput);
+
+            try
+            {
+                AssemblyName impostor = new AssemblyName("CoseSign1Plus");
+                Assembly? result = InvokeLoad(context, impostor);
+
+                // Assert
+                Assert.IsNull(result, "Stub file should fail to load and return null");
+
+                string stderr = consoleOutput.ToString();
+                Assert.IsTrue(
+                    stderr.Contains("CoseSign1Plus", StringComparison.OrdinalIgnoreCase),
+                    $"Plugin-local load attempt for 'CoseSign1Plus' should have produced a warning. Captured stderr: '{stderr}'");
+            }
+            finally
+            {
+                Console.SetError(originalError);
+                consoleOutput.Dispose();
+            }
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    /// <summary>
+    /// Regression test for the resolver-bypass guarantee. When a name is host-shared, the loader
+    /// MUST NOT probe the plugin directory or the AssemblyDependencyResolver — even if a same-named
+    /// DLL is present in the plugin directory. Otherwise a malformed plugin-local copy could
+    /// surface a confusing error or, worse, split type identity from the host.
+    /// </summary>
+    [TestMethod]
+    public void Integration_SharedNameWithDuplicateInPluginDir_ShortCircuitsResolver()
+    {
+        // Arrange
+        string pluginPath = Path.Join(_pluginDirectory, "Main.dll");
+        File.WriteAllText(pluginPath, "main plugin content");
+
+        // Place a stub "CoseSignTool.Abstractions.dll" in the plugin directory. If the loader
+        // probed plugin-local first, it would attempt to load this stub and write a warning. We
+        // assert the warning is NOT written, proving the short-circuit happens before any probe.
+        string stubSharedPath = Path.Join(_pluginDirectory, "CoseSignTool.Abstractions.dll");
+        File.WriteAllBytes(stubSharedPath, Encoding.UTF8.GetBytes("MZ"));
+
+        PluginLoadContext context = new PluginLoadContext(pluginPath, _pluginDirectory);
+
+        try
+        {
+            StringWriter consoleOutput = new StringWriter();
+            TextWriter originalError = Console.Error;
+            Console.SetError(consoleOutput);
+
+            try
+            {
+                AssemblyName sharedName = new AssemblyName("CoseSignTool.Abstractions");
+                Assembly? result = InvokeLoad(context, sharedName);
+
+                // Assert
+                Assert.IsNull(result, "Shared name should return null so the default ALC handles it");
+
+                string stderr = consoleOutput.ToString();
+                Assert.IsFalse(
+                    stderr.Contains("CoseSignTool.Abstractions", StringComparison.OrdinalIgnoreCase),
+                    $"Shared name must short-circuit BEFORE plugin-local probe — no warning expected. Captured stderr: '{stderr}'");
+            }
+            finally
+            {
+                Console.SetError(originalError);
+                consoleOutput.Dispose();
             }
         }
         finally

--- a/CoseSignTool.Abstractions.Tests/PluginLoadContextIntegrationTests.cs
+++ b/CoseSignTool.Abstractions.Tests/PluginLoadContextIntegrationTests.cs
@@ -212,7 +212,7 @@ public class PluginLoadContextIntegrationTests
         {
             // Act — capture stderr to confirm the plugin-local probe was attempted (proof that
             // the shared-list short-circuit did NOT consume this name).
-            StringWriter consoleOutput = new StringWriter();
+            using StringWriter consoleOutput = new StringWriter();
             TextWriter originalError = Console.Error;
             Console.SetError(consoleOutput);
 
@@ -232,7 +232,6 @@ public class PluginLoadContextIntegrationTests
             finally
             {
                 Console.SetError(originalError);
-                consoleOutput.Dispose();
             }
         }
         finally
@@ -264,7 +263,7 @@ public class PluginLoadContextIntegrationTests
 
         try
         {
-            StringWriter consoleOutput = new StringWriter();
+            using StringWriter consoleOutput = new StringWriter();
             TextWriter originalError = Console.Error;
             Console.SetError(consoleOutput);
 
@@ -284,7 +283,6 @@ public class PluginLoadContextIntegrationTests
             finally
             {
                 Console.SetError(originalError);
-                consoleOutput.Dispose();
             }
         }
         finally

--- a/CoseSignTool.Abstractions/CertificateProviderPluginManager.cs
+++ b/CoseSignTool.Abstractions/CertificateProviderPluginManager.cs
@@ -81,6 +81,13 @@ public class CertificateProviderPluginManager
     /// Loads certificate provider plugins from the specified assembly file.
     /// </summary>
     /// <param name="assemblyPath">Path to the assembly file to load plugins from.</param>
+    /// <remarks>
+    /// Each plugin assembly is loaded into its own isolated <see cref="PluginLoadContext"/> so
+    /// that the plugin's private dependencies (e.g. Azure SDK transitives) cannot bleed into the
+    /// host or sibling plugins. Only assemblies in the curated host-shared list (defined on
+    /// <see cref="PluginLoadContext"/>) are sourced from the host context — everything else is
+    /// resolved plugin-locally from the directory containing the plugin assembly.
+    /// </remarks>
     public void LoadPluginFromAssembly(string assemblyPath)
     {
         if (!File.Exists(assemblyPath))
@@ -90,12 +97,14 @@ public class CertificateProviderPluginManager
 
         _logger?.LogVerbose($"Loading plugins from: {Path.GetFileName(assemblyPath)}");
 
-        Assembly assembly = Assembly.LoadFrom(assemblyPath);
-        
+        string pluginDirectory = Path.GetDirectoryName(assemblyPath) ?? AppContext.BaseDirectory;
+        PluginLoadContext loadContext = new PluginLoadContext(assemblyPath, pluginDirectory);
+        Assembly assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+
         // Find all types implementing ICertificateProviderPlugin
         Type[] types = assembly.GetTypes()
-            .Where(t => typeof(ICertificateProviderPlugin).IsAssignableFrom(t) 
-                        && !t.IsInterface 
+            .Where(t => typeof(ICertificateProviderPlugin).IsAssignableFrom(t)
+                        && !t.IsInterface
                         && !t.IsAbstract)
             .ToArray();
 

--- a/CoseSignTool.Abstractions/PluginLoadContext.cs
+++ b/CoseSignTool.Abstractions/PluginLoadContext.cs
@@ -203,7 +203,7 @@ public class PluginLoadContext : AssemblyLoadContext
             {
                 return LoadFromAssemblyPath(expectedPath);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException or FileLoadException or ArgumentException)
             {
                 Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from '{expectedPath}': {ex.Message}");
             }
@@ -216,7 +216,7 @@ public class PluginLoadContext : AssemblyLoadContext
             {
                 return LoadFromAssemblyPath(assemblyPath);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException or FileLoadException or ArgumentException)
             {
                 Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from resolver path '{assemblyPath}': {ex.Message}");
             }

--- a/CoseSignTool.Abstractions/PluginLoadContext.cs
+++ b/CoseSignTool.Abstractions/PluginLoadContext.cs
@@ -203,7 +203,7 @@ public class PluginLoadContext : AssemblyLoadContext
             {
                 return LoadFromAssemblyPath(expectedPath);
             }
-            catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException or FileLoadException or ArgumentException)
+            catch (Exception ex) // CodeQL [SM02184] Plugin loader boundary: LoadFromAssemblyPath can transitively trigger module/type initializers that throw arbitrary exceptions (e.g. TypeInitializationException, PlatformNotSupportedException). A misbehaving plugin dependency must not crash the host; we log and fall through so the runtime can probe alternate paths.
             {
                 Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from '{expectedPath}': {ex.Message}");
             }
@@ -216,7 +216,7 @@ public class PluginLoadContext : AssemblyLoadContext
             {
                 return LoadFromAssemblyPath(assemblyPath);
             }
-            catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException or FileLoadException or ArgumentException)
+            catch (Exception ex) // CodeQL [SM02184] Plugin loader boundary: see rationale above. Resolver-supplied paths are also subject to type-initializer failures originating inside plugin dependencies; swallow-and-log preserves host stability.
             {
                 Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from resolver path '{assemblyPath}': {ex.Message}");
             }

--- a/CoseSignTool.Abstractions/PluginLoadContext.cs
+++ b/CoseSignTool.Abstractions/PluginLoadContext.cs
@@ -7,59 +7,195 @@ using System.Runtime.Loader;
 namespace CoseSignTool.Abstractions;
 
 /// <summary>
-/// Custom AssemblyLoadContext for loading plugins with isolated dependencies.
-/// Each plugin gets its own context to avoid dependency conflicts.
+/// Custom <see cref="AssemblyLoadContext"/> that isolates a plugin's dependencies in its own
+/// collectible context while sharing a small, deterministic, audited set of cross-boundary
+/// contract assemblies with the host.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Sharing is decided by two mechanisms:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <b>Framework prefix match</b> — a tiny prefix list capturing the .NET / BCL families
+///     (<c>System.*</c>, <c>Microsoft.Extensions.*</c>, <c>Microsoft.NETCore.*</c>) plus exact
+///     framework names (<c>System</c>, <c>mscorlib</c>, <c>netstandard</c>). These namespaces are
+///     owned by Microsoft / the .NET runtime and have no third-party collision risk.
+///   </item>
+///   <item>
+///     <b>Exact-name allow-list</b> — a curated <see cref="HashSet{T}"/> of repo-owned assemblies
+///     whose types cross the host/plugin boundary as method parameters or return values.
+///     <b>Exact-name only</b>: prefix matching here would risk false positives (e.g. a 3rd-party
+///     <c>CoseSign1Plus.dll</c> being silently absorbed into the host context).
+///   </item>
+/// </list>
+/// <para>
+/// The shared decision <b>short-circuits</b> the per-plugin probing logic: if a name is
+/// host-shared, <see cref="Load"/> returns <c>null</c> immediately without touching the plugin
+/// directory or the <see cref="AssemblyDependencyResolver"/>. This prevents a duplicate type
+/// identity from appearing if the plugin happens to ship a copy of the same DLL.
+/// </para>
+/// <para>
+/// What is intentionally <b>NOT</b> shared (so plugins remain isolated):
+/// <list type="bullet">
+///   <item><c>CoseHandler</c>, <c>CoseIndirectSignature</c> — used by host and plugins via static
+///         method calls only; instances do not cross the boundary.</item>
+///   <item><c>CoseSign1.Certificates</c> — host downcasts use
+///         <see cref="CoseSign1.Abstractions.Interfaces.ISupportsScittCompliance"/> instead of the
+///         concrete <c>CertificateCoseSigningKeyProvider</c> type.</item>
+///   <item><c>CoseSign1.Transparent.MST</c>, <c>CoseSign1.Certificates.AzureArtifactSigning</c> —
+///         fully plugin-local. The shared library and the SDK types it extends now co-locate in
+///         the plugin's ALC, removing the type-identity bug class entirely.</item>
+///   <item><c>Azure.*</c> SDK packages — only used inside individual plugins.</item>
+///   <item><c>Newtonsoft.Json</c> — plugins ship their own copy if they use it.</item>
+/// </list>
+/// </para>
+/// </remarks>
 public class PluginLoadContext : AssemblyLoadContext
 {
-    private readonly AssemblyDependencyResolver _resolver;
-    private readonly string _pluginDirectory;
+    /// <summary>
+    /// Framework / BCL assembly-name prefixes always sourced from the host. These namespaces are
+    /// owned by Microsoft / the .NET ecosystem; prefix matching here is collision-safe.
+    /// </summary>
+    private static readonly string[] FrameworkPrefixes =
+    {
+        "System.",
+        "Microsoft.Extensions.",
+        "Microsoft.NETCore.",
+    };
 
     /// <summary>
-    /// Initializes a new instance of the PluginLoadContext class.
+    /// Bare framework assembly names (no trailing dot) that must be sourced from the host.
+    /// Exact-name match — bare <c>"System"</c> would otherwise collide with anything starting
+    /// with the letters S-y-s-t-e-m.
+    /// </summary>
+    private static readonly IReadOnlySet<string> FrameworkExactNames =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "System",
+            "mscorlib",
+            "netstandard",
+            "WindowsBase",
+            "Microsoft.CSharp",
+            "Microsoft.VisualBasic",
+        };
+
+    /// <summary>
+    /// Repo-curated cross-boundary contract assemblies. Exact-name match only.
+    /// </summary>
+    /// <remarks>
+    /// Adding to this list expands the host/plugin shared-type surface — review carefully. Each
+    /// entry must justify itself with a concrete type that crosses the host/plugin boundary as a
+    /// method parameter, return value, generic argument, or interface implementation.
+    /// </remarks>
+    private static readonly IReadOnlySet<string> SharedAssemblies =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Plugin contracts: ICoseSignToolPlugin, IPluginCommand, ICertificateProviderPlugin,
+            // IPluginLogger, PluginExitCode, CoseHeaderHelper, CoseHeaderDto<T>.
+            "CoseSignTool.Abstractions",
+
+            // Cose contracts: ICoseSigningKeyProvider (returned by ICertificateProviderPlugin),
+            // ISupportsScittCompliance (host capability check on plugin-returned providers).
+            "CoseSign1.Abstractions",
+
+            // ICoseHeaderExtender flows out of CoseHeaderHelper.CreateHeaderExtender (which lives
+            // in CoseSignTool.Abstractions) and is consumed by plugin signing commands. Both sides
+            // must agree on the interface's type identity.
+            "CoseSign1.Headers",
+        };
+
+    private readonly AssemblyDependencyResolver dependencyResolver;
+    private readonly string pluginDirectory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginLoadContext"/> class.
     /// </summary>
     /// <param name="pluginPath">The path to the main plugin assembly.</param>
     /// <param name="pluginDirectory">The directory containing the plugin and its dependencies.</param>
     public PluginLoadContext(string pluginPath, string pluginDirectory) : base(isCollectible: true)
     {
-        _resolver = new AssemblyDependencyResolver(pluginPath);
-        _pluginDirectory = pluginDirectory;
+        this.dependencyResolver = new AssemblyDependencyResolver(pluginPath);
+        this.pluginDirectory = pluginDirectory;
+    }
+
+    /// <summary>
+    /// Determines whether the assembly with the specified simple name should be sourced from the
+    /// host <see cref="AssemblyLoadContext"/> rather than loaded plugin-locally.
+    /// </summary>
+    /// <param name="assemblyName">The simple assembly name (e.g. <c>"CoseSign1.Abstractions"</c>).</param>
+    /// <returns><c>true</c> when the host owns this assembly; <c>false</c> otherwise.</returns>
+    /// <remarks>
+    /// Public so test code can verify the contract without reflection. The decision is two-tier:
+    /// (1) framework prefix or exact framework name, (2) repo-curated exact-name allow-list.
+    /// Prefix matching is intentionally restricted to .NET-owned namespaces.
+    /// </remarks>
+    public static bool IsHostShared(string? assemblyName)
+    {
+        if (string.IsNullOrEmpty(assemblyName))
+        {
+            return false;
+        }
+
+        if (FrameworkExactNames.Contains(assemblyName) || SharedAssemblies.Contains(assemblyName))
+        {
+            return true;
+        }
+
+        for (int i = 0; i < FrameworkPrefixes.Length; i++)
+        {
+            if (assemblyName.StartsWith(FrameworkPrefixes[i], StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
     /// Loads an assembly with the specified name.
-    /// First tries to resolve from the plugin directory, then falls back to default context.
     /// </summary>
     /// <param name="assemblyName">The name of the assembly to load.</param>
-    /// <returns>The loaded assembly, or null if not found.</returns>
+    /// <returns>The loaded assembly, or <c>null</c> to delegate to the default context.</returns>
+    /// <remarks>
+    /// Order of operations is critical:
+    /// <list type="number">
+    ///   <item>If the name is host-shared, return <c>null</c> immediately. Do <b>not</b> probe the
+    ///         plugin directory or the resolver — doing so risks loading a duplicate copy that
+    ///         would split type identity from the host.</item>
+    ///   <item>Otherwise, look in the plugin directory directly.</item>
+    ///   <item>If not found there, ask the <see cref="AssemblyDependencyResolver"/>.</item>
+    ///   <item>If still not found, return <c>null</c> and let the runtime fall back to the
+    ///         default context (which will likely fail — by design — for plugin-private deps).</item>
+    /// </list>
+    /// </remarks>
     protected override Assembly? Load(AssemblyName assemblyName)
     {
-        // For shared dependencies (like Microsoft.Extensions.*, System.*, etc.),
-        // let the default context handle them to avoid duplicating framework assemblies
-        if (IsSharedFrameworkAssembly(assemblyName))
+        if (assemblyName.Name == null)
         {
-            return null; // This will fall back to the default context
+            return null;
         }
 
-        // Look for the assembly directly in the plugin directory first
-        if (assemblyName.Name != null)
+        if (IsHostShared(assemblyName.Name))
         {
-            string expectedPath = Path.Join(_pluginDirectory, $"{assemblyName.Name}.dll");
-            if (File.Exists(expectedPath))
+            return null;
+        }
+
+        string expectedPath = Path.Join(this.pluginDirectory, $"{assemblyName.Name}.dll");
+        if (File.Exists(expectedPath))
+        {
+            try
             {
-                try
-                {
-                    return LoadFromAssemblyPath(expectedPath);
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from '{expectedPath}': {ex.Message}");
-                }
+                return LoadFromAssemblyPath(expectedPath);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from '{expectedPath}': {ex.Message}");
             }
         }
 
-        // Try to resolve the assembly from the plugin directory using the dependency resolver
-        string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        string? assemblyPath = this.dependencyResolver.ResolveAssemblyToPath(assemblyName);
         if (assemblyPath != null && File.Exists(assemblyPath))
         {
             try
@@ -72,60 +208,17 @@ public class PluginLoadContext : AssemblyLoadContext
             }
         }
 
-        // If we can't find the assembly, return null to allow default loading
         return null;
-    }
-
-    /// <summary>
-    /// Determines if an assembly should be loaded from the shared framework rather than plugin-specific.
-    /// </summary>
-    /// <param name="assemblyName">The assembly name to check.</param>
-    /// <returns>True if this is a shared framework assembly.</returns>
-    private static bool IsSharedFrameworkAssembly(AssemblyName assemblyName)
-    {
-        if (assemblyName.Name == null)
-        {
-            return false;
-        }
-
-        // These should come from the main application context to avoid conflicts
-        string[] sharedPrefixes =
-        [
-            "System.",
-            "Microsoft.Extensions.",
-            "Microsoft.NETCore.",
-            "netstandard",
-            "mscorlib",
-            "System",
-            "Newtonsoft.Json",
-            "CoseSignTool.Abstractions", // Always use the main version
-            "CoseHandler",               // Shared components
-            "CoseSign1",
-            "CoseIndirectSignature",
-            // Azure SDK assemblies that are referenced by shared CoseSign1.* assemblies
-            // and whose types cross the plugin/host boundary. They MUST load in the same
-            // AssemblyLoadContext as the shared assemblies that reference them, otherwise
-            // type identity mismatches cause MissingMethodException at runtime
-            // (e.g., CoseSign1.Transparent.MST.MstClientOptionsExtensions binds to the
-            // host-context CodeTransparencyClientOptions, but a plugin would otherwise
-            // construct a plugin-context instance — the two are distinct types).
-            "Azure.Security.CodeTransparency",
-            "Azure.CodeSigning",
-            "Azure.Developer.ArtifactSigning",
-            "Azure.Core"
-        ];
-
-        return sharedPrefixes.Any(prefix => assemblyName.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
     /// Loads an unmanaged library with the specified name.
     /// </summary>
     /// <param name="unmanagedDllName">The name of the unmanaged library.</param>
-    /// <returns>A handle to the loaded library, or IntPtr.Zero if not found.</returns>
+    /// <returns>A handle to the loaded library, or <see cref="IntPtr.Zero"/> if not found.</returns>
     protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
     {
-        string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        string? libraryPath = this.dependencyResolver.ResolveUnmanagedDllToPath(unmanagedDllName);
         if (libraryPath != null && File.Exists(libraryPath))
         {
             return LoadUnmanagedDllFromPath(libraryPath);
@@ -134,3 +227,4 @@ public class PluginLoadContext : AssemblyLoadContext
         return IntPtr.Zero;
     }
 }
+

--- a/CoseSignTool.Abstractions/PluginLoadContext.cs
+++ b/CoseSignTool.Abstractions/PluginLoadContext.cs
@@ -18,9 +18,13 @@ namespace CoseSignTool.Abstractions;
 /// <list type="number">
 ///   <item>
 ///     <b>Framework prefix match</b> — a tiny prefix list capturing the .NET / BCL families
-///     (<c>System.*</c>, <c>Microsoft.Extensions.*</c>, <c>Microsoft.NETCore.*</c>) plus exact
-///     framework names (<c>System</c>, <c>mscorlib</c>, <c>netstandard</c>). These namespaces are
-///     owned by Microsoft / the .NET runtime and have no third-party collision risk.
+///     (<c>Microsoft.Extensions.*</c>, <c>Microsoft.NETCore.*</c>) plus exact framework names
+///     (bare <c>System</c>, <c>mscorlib</c>, <c>netstandard</c>). True BCL <c>System.*</c>
+///     assemblies (<c>System.Collections</c>, <c>System.Runtime</c>, etc.) are not listed
+///     explicitly; they live in TPA and are resolved by the runtime's default-context fallback
+///     when our <see cref="Load"/> returns null. This intentionally allows out-of-band NuGet
+///     packages with <c>System.*</c> names (<c>System.ClientModel</c>, <c>System.Memory.Data</c>,
+///     <c>System.IO.Pipelines</c>, etc.) to be loaded plugin-locally.
 ///   </item>
 ///   <item>
 ///     <b>Exact-name allow-list</b> — a curated <see cref="HashSet{T}"/> of repo-owned assemblies
@@ -46,7 +50,8 @@ namespace CoseSignTool.Abstractions;
 ///   <item><c>CoseSign1.Transparent.MST</c>, <c>CoseSign1.Certificates.AzureArtifactSigning</c> —
 ///         fully plugin-local. The shared library and the SDK types it extends now co-locate in
 ///         the plugin's ALC, removing the type-identity bug class entirely.</item>
-///   <item><c>Azure.*</c> SDK packages — only used inside individual plugins.</item>
+///   <item><c>Azure.*</c> SDK packages and out-of-band <c>System.*</c> NuGet packages — only used
+///         inside individual plugins.</item>
 ///   <item><c>Newtonsoft.Json</c> — plugins ship their own copy if they use it.</item>
 /// </list>
 /// </para>
@@ -54,12 +59,21 @@ namespace CoseSignTool.Abstractions;
 public class PluginLoadContext : AssemblyLoadContext
 {
     /// <summary>
-    /// Framework / BCL assembly-name prefixes always sourced from the host. These namespaces are
-    /// owned by Microsoft / the .NET ecosystem; prefix matching here is collision-safe.
+    /// Framework / BCL assembly-name prefixes always sourced from the host. <c>Microsoft.Extensions.*</c>
+    /// is treated as a shared family because <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>
+    /// (and helpers around it) cross the host/plugin boundary, and the .NET ecosystem co-versions
+    /// these packages carefully.
     /// </summary>
+    /// <remarks>
+    /// <c>System.*</c> is intentionally NOT here — that namespace is mixed: BCL assemblies
+    /// (<c>System.Collections</c>, <c>System.Runtime</c>) live in TPA and resolve naturally via the
+    /// default context fallback when our <see cref="Load"/> returns null, while
+    /// out-of-band NuGet packages with <c>System.*</c> names (<c>System.ClientModel</c>,
+    /// <c>System.Memory.Data</c>, <c>System.IO.Pipelines</c>, etc.) are legitimate plugin-private
+    /// dependencies that must be loadable from the plugin directory.
+    /// </remarks>
     private static readonly string[] FrameworkPrefixes =
     {
-        "System.",
         "Microsoft.Extensions.",
         "Microsoft.NETCore.",
     };

--- a/CoseSignTool.Abstractions/PluginLoadContext.cs
+++ b/CoseSignTool.Abstractions/PluginLoadContext.cs
@@ -101,7 +101,18 @@ public class PluginLoadContext : AssemblyLoadContext
             "CoseSignTool.Abstractions", // Always use the main version
             "CoseHandler",               // Shared components
             "CoseSign1",
-            "CoseIndirectSignature"
+            "CoseIndirectSignature",
+            // Azure SDK assemblies that are referenced by shared CoseSign1.* assemblies
+            // and whose types cross the plugin/host boundary. They MUST load in the same
+            // AssemblyLoadContext as the shared assemblies that reference them, otherwise
+            // type identity mismatches cause MissingMethodException at runtime
+            // (e.g., CoseSign1.Transparent.MST.MstClientOptionsExtensions binds to the
+            // host-context CodeTransparencyClientOptions, but a plugin would otherwise
+            // construct a plugin-context instance — the two are distinct types).
+            "Azure.Security.CodeTransparency",
+            "Azure.CodeSigning",
+            "Azure.Developer.ArtifactSigning",
+            "Azure.Core"
         ];
 
         return sharedPrefixes.Any(prefix => assemblyName.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));

--- a/CoseSignTool.Abstractions/PluginLoadContext.cs
+++ b/CoseSignTool.Abstractions/PluginLoadContext.cs
@@ -203,7 +203,10 @@ public class PluginLoadContext : AssemblyLoadContext
             {
                 return LoadFromAssemblyPath(expectedPath);
             }
-            catch (Exception ex) // CodeQL [SM02184] Plugin loader boundary: LoadFromAssemblyPath can transitively trigger module/type initializers that throw arbitrary exceptions (e.g. TypeInitializationException, PlatformNotSupportedException). A misbehaving plugin dependency must not crash the host; we log and fall through so the runtime can probe alternate paths.
+            catch (Exception ex) when (ex is not OutOfMemoryException
+                                          and not StackOverflowException
+                                          and not ThreadAbortException
+                                          and not AccessViolationException)
             {
                 Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from '{expectedPath}': {ex.Message}");
             }
@@ -216,7 +219,10 @@ public class PluginLoadContext : AssemblyLoadContext
             {
                 return LoadFromAssemblyPath(assemblyPath);
             }
-            catch (Exception ex) // CodeQL [SM02184] Plugin loader boundary: see rationale above. Resolver-supplied paths are also subject to type-initializer failures originating inside plugin dependencies; swallow-and-log preserves host stability.
+            catch (Exception ex) when (ex is not OutOfMemoryException
+                                          and not StackOverflowException
+                                          and not ThreadAbortException
+                                          and not AccessViolationException)
             {
                 Console.Error.WriteLine($"Warning: Failed to load assembly '{assemblyName.Name}' from resolver path '{assemblyPath}': {ex.Message}");
             }

--- a/CoseSignTool.AzureArtifactSigning.Plugin/AzureArtifactSigningCertificateProviderPlugin.cs
+++ b/CoseSignTool.AzureArtifactSigning.Plugin/AzureArtifactSigningCertificateProviderPlugin.cs
@@ -3,8 +3,10 @@
 
 namespace CoseSignTool.AzureArtifactSigning.Plugin;
 
+using Azure.CodeSigning;
 using Azure.Core;
 using Azure.Developer.ArtifactSigning.CryptoProvider;
+using Azure.Developer.ArtifactSigning.CryptoProvider.Models;
 using Azure.Identity;
 using CoseSign1.Certificates.AzureArtifactSigning;
 using System;
@@ -103,20 +105,31 @@ public class AzureArtifactSigningCertificateProviderPlugin : ICertificateProvide
             });
 
             logger?.LogVerbose("Creating CertificateProfileClient...");
-            // Create the Certificate Profile Client
+            // Create the Certificate Profile Client with fast-retry pipeline tuning so transient
+            // Azure SDK retries do not balloon interactive signing latency. The default 800 ms
+            // exponential back-off (3 retries, ~5 s ceiling) is replaced with 250 ms fixed retries
+            // (8 retries, ~2 s ceiling). Callers can override via ConfigureAasPerformanceOptimizations.
+            CertificateProfileClientOptions clientOptions = new();
+            clientOptions.ConfigureAasPerformanceOptimizations();
+
             // Constructor: CertificateProfileClient(TokenCredential credential, Uri endpoint, options)
             Uri endpointUri = new Uri(endpoint);
-            var certificateProfileClient = new Azure.CodeSigning.CertificateProfileClient(
+            Azure.CodeSigning.CertificateProfileClient certificateProfileClient = new Azure.CodeSigning.CertificateProfileClient(
                 credential,
-                endpointUri);
+                endpointUri,
+                clientOptions);
 
             logger?.LogVerbose("Creating AzSignContext...");
-            // Create AzSignContext using the certificate profile client
-            // Constructor: AzSignContext(accountName, certProfile, cpClient, ...)
+            // Create AzSignContext with explicit performance options. Defaults match the SDK
+            // baseline (3 task retries, 60 s task timeout) — surfaced here so future tuning
+            // touches a single point.
+            AzSignContextOptions signContextOptions = AasClientOptionsExtensions.ConfigureAasSigningPerformance();
             AzSignContext signContext = new AzSignContext(
                 accountName,
                 certProfileName,
-                certificateProfileClient);
+                certificateProfileClient,
+                null,
+                signContextOptions);
 
             logger?.LogVerbose("Creating AzureArtifactSigningCoseSigningKeyProvider...");
             // Create and return the key provider

--- a/CoseSignTool.MST.Plugin.Tests/MstPluginTests.cs
+++ b/CoseSignTool.MST.Plugin.Tests/MstPluginTests.cs
@@ -415,31 +415,55 @@ public class VerifyCommandTests
 /// <summary>
 /// Tests for the CodeTransparencyClientHelper class.
 /// </summary>
+/// <remarks>
+/// Marked <see cref="DoNotParallelizeAttribute"/> because every test mutates the process-wide
+/// environment variables <c>MST_TOKEN</c> and <c>TEST_CTS_TOKEN</c>. Even with per-test
+/// try/finally blocks, concurrent execution within the class would race on the env-var slot.
+/// <see cref="TestInitialize"/> / <see cref="TestCleanup"/> snapshot and restore the values
+/// so a test that throws en route still leaves the process clean for downstream classes.
+/// </remarks>
 [TestClass]
+[DoNotParallelize]
 public class CodeTransparencyClientHelperTests
 {
     private const string TestEndpoint = "https://test.confidential-ledger.azure.com";
     private const string TestToken = "test-token-12345";
     private const string TestEnvVarName = "TEST_CTS_TOKEN";
 
+    private string? OriginalMstToken;
+    private string? OriginalTestEnvVar;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        OriginalMstToken = Environment.GetEnvironmentVariable("MST_TOKEN");
+        OriginalTestEnvVar = Environment.GetEnvironmentVariable(TestEnvVarName);
+
+        // Start every test from a known-clean env-var state.
+        Environment.SetEnvironmentVariable("MST_TOKEN", null);
+        Environment.SetEnvironmentVariable(TestEnvVarName, null);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        // Restore whatever the host shell had set so other test classes (or interactive
+        // re-runs) are unaffected by our mutations, even if a test threw mid-flight.
+        Environment.SetEnvironmentVariable("MST_TOKEN", OriginalMstToken);
+        Environment.SetEnvironmentVariable(TestEnvVarName, OriginalTestEnvVar);
+    }
+
     [TestMethod]
     public async Task CreateClientAsync_WithTokenFromDefaultEnvironmentVariable_CreatesClient()
     {
         // Arrange
         Environment.SetEnvironmentVariable("MST_TOKEN", TestToken);
-        try
-        {
-            // Act
-            Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, null);
 
-            // Assert
-            Assert.IsNotNull(client);
-        }
-        finally
-        {
-            // Cleanup
-            Environment.SetEnvironmentVariable("MST_TOKEN", null);
-        }
+        // Act
+        Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, null, useAzureAuth: false);
+
+        // Assert
+        Assert.IsNotNull(client);
     }
 
     [TestMethod]
@@ -447,75 +471,157 @@ public class CodeTransparencyClientHelperTests
     {
         // Arrange
         Environment.SetEnvironmentVariable(TestEnvVarName, TestToken);
-        try
-        {
-            // Act
-            Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, TestEnvVarName);
 
-            // Assert
-            Assert.IsNotNull(client);
-        }
-        finally
-        {
-            // Cleanup
-            Environment.SetEnvironmentVariable(TestEnvVarName, null);
-        }
+        // Act
+        Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, TestEnvVarName, useAzureAuth: false);
+
+        // Assert
+        Assert.IsNotNull(client);
     }
 
     [TestMethod]
-    public async Task CreateClientAsync_WithoutTokenEnvironmentVariable_UsesDefaultCredential()
+    public async Task CreateClientAsync_WithoutTokenAndDefaults_CreatesAnonymousClient()
     {
-        // Arrange
-        Environment.SetEnvironmentVariable("MST_TOKEN", null);
-        Environment.SetEnvironmentVariable(TestEnvVarName, null);
+        // Arrange — env vars are clean per [TestInitialize].
 
+        // Act - default behaviour (useAzureAuth=false) yields an anonymous client; no
+        // network or credential acquisition occurs.
+        Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, null, useAzureAuth: false);
+
+        // Assert
+        Assert.IsNotNull(client);
+    }
+
+    [TestMethod]
+    public async Task CreateClientAsync_WithoutTokenAndAzureAuth_UsesDefaultCredential()
+    {
+        // Arrange — env vars are clean per [TestInitialize].
         try
         {
             // Act
-            Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, TestEnvVarName);
+            Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, null, useAzureAuth: true);
 
             // Assert
-            // If DefaultAzureCredential succeeds (e.g., Azure CLI is logged in), the client should be created
+            // If DefaultAzureCredential succeeds (e.g., Azure CLI is logged in), the client should be created.
             Assert.IsNotNull(client);
         }
         catch (Azure.Identity.CredentialUnavailableException)
         {
-            // Assert
-            // In a test environment without Azure credentials, DefaultAzureCredential will throw CredentialUnavailableException
-            // This is also valid behavior - the method attempted to use DefaultAzureCredential as expected
+            // In a test environment without Azure credentials, DefaultAzureCredential will throw
+            // CredentialUnavailableException. That is also valid behaviour for this opt-in path.
             Assert.IsTrue(true, "DefaultAzureCredential correctly threw CredentialUnavailableException when no credentials are available");
         }
     }
 
     [TestMethod]
-    public async Task CreateClientAsync_WithEmptyTokenEnvironmentVariable_UsesDefaultCredential()
+    public async Task CreateClientAsync_WithExplicitTokenEnvButMissingValue_ThrowsInvalidOperation()
+    {
+        // Arrange — explicit env var name supplied but the env var is unset (per [TestInitialize]).
+
+        // Act / Assert
+        InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, TestEnvVarName, useAzureAuth: false));
+        StringAssert.Contains(ex.Message, TestEnvVarName);
+    }
+
+    [TestMethod]
+    public async Task CreateClientAsync_WithExplicitTokenEnvButWhitespaceValue_ThrowsInvalidOperation()
+    {
+        // Arrange — explicit env var name supplied but the env var is whitespace.
+        Environment.SetEnvironmentVariable(TestEnvVarName, "   ");
+
+        // Act / Assert
+        InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, TestEnvVarName, useAzureAuth: false));
+        StringAssert.Contains(ex.Message, TestEnvVarName);
+    }
+
+    [TestMethod]
+    public async Task CreateClientAsync_WithBothTokenAndAzureAuth_TokenWins()
     {
         // Arrange
-        Environment.SetEnvironmentVariable(TestEnvVarName, "");
-        try
-        {
-            try
-            {
-                // Act
-                Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, TestEnvVarName);
+        Environment.SetEnvironmentVariable("MST_TOKEN", TestToken);
 
-                // Assert
-                // If DefaultAzureCredential succeeds (e.g., Azure CLI is logged in), the client should be created
-                Assert.IsNotNull(client);
-            }
-            catch (Azure.Identity.CredentialUnavailableException)
-            {
-                // Assert
-                // In a test environment without Azure credentials, DefaultAzureCredential will throw CredentialUnavailableException
-                // This is also valid behavior - the method attempted to use DefaultAzureCredential as expected
-                Assert.IsTrue(true, "DefaultAzureCredential correctly threw CredentialUnavailableException when no credentials are available");
-            }
-        }
-        finally
-        {
-            // Cleanup
-            Environment.SetEnvironmentVariable(TestEnvVarName, null);
-        }
+        // Act — even with --azure-auth set, an explicit MST_TOKEN should be used
+        // (no DefaultAzureCredential acquisition takes place).
+        Azure.Security.CodeTransparency.CodeTransparencyClient client = await CodeTransparencyClientHelper.CreateClientAsync(TestEndpoint, null, useAzureAuth: true);
+
+        // Assert
+        Assert.IsNotNull(client);
     }
 }
+
+/// <summary>
+/// Tests that verify the <c>--azure-auth</c> CLI flag is wired correctly through the option
+/// metadata on both MST commands. These exercise the boolean-flag plumbing — a missing
+/// <c>BooleanOptions</c> entry would cause the host CLI parser to reject a bare
+/// <c>--azure-auth</c>, which would silently re-introduce the bug we just fixed.
+/// </summary>
+[TestClass]
+public class MstAzureAuthFlagWiringTests
+{
+    [TestMethod]
+    public void RegisterCommand_Options_ContainsAzureAuth()
+    {
+        // Arrange
+        RegisterCommand command = new RegisterCommand();
+
+        // Assert
+        Assert.IsTrue(command.Options.ContainsKey("azure-auth"),
+            "RegisterCommand.Options must include azure-auth so the CLI parser recognises --azure-auth.");
+    }
+
+    [TestMethod]
+    public void RegisterCommand_BooleanOptions_ContainsAzureAuth()
+    {
+        // Arrange
+        RegisterCommand command = new RegisterCommand();
+
+        // Assert
+        Assert.IsTrue(command.BooleanOptions.Contains("azure-auth"),
+            "RegisterCommand.BooleanOptions must include azure-auth so a bare --azure-auth is accepted without a value.");
+    }
+
+    [TestMethod]
+    public void VerifyCommand_Options_ContainsAzureAuth()
+    {
+        // Arrange
+        VerifyCommand command = new VerifyCommand();
+
+        // Assert
+        Assert.IsTrue(command.Options.ContainsKey("azure-auth"),
+            "VerifyCommand.Options must include azure-auth so the CLI parser recognises --azure-auth.");
+    }
+
+    [TestMethod]
+    public void VerifyCommand_BooleanOptions_ContainsAzureAuth()
+    {
+        // Arrange
+        VerifyCommand command = new VerifyCommand();
+
+        // Assert
+        Assert.IsTrue(command.BooleanOptions.Contains("azure-auth"),
+            "VerifyCommand.BooleanOptions must include azure-auth so a bare --azure-auth is accepted without a value.");
+    }
+
+    [TestMethod]
+    public void BooleanOptions_IsSharedAcrossInstances()
+    {
+        // Arrange
+        RegisterCommand register1 = new RegisterCommand();
+        RegisterCommand register2 = new RegisterCommand();
+        VerifyCommand verify = new VerifyCommand();
+
+        // Assert
+        // Locks in the perf optimisation: BooleanOptions is backed by a single static array,
+        // not allocated per instance. ReferenceEquals on the underlying collection guarantees this.
+        Assert.AreSame(register1.BooleanOptions, register2.BooleanOptions,
+            "RegisterCommand.BooleanOptions must be the same reference across instances (backed by static readonly).");
+        Assert.AreSame(register1.BooleanOptions, verify.BooleanOptions,
+            "BooleanOptions must be the same reference across all MST commands (shared static readonly).");
+    }
+}
+
+
+
 

--- a/CoseSignTool.MST.Plugin/CodeTransparencyClientHelper.cs
+++ b/CoseSignTool.MST.Plugin/CodeTransparencyClientHelper.cs
@@ -13,41 +13,94 @@ using System.Text.Json;
 internal static class CodeTransparencyClientHelper
 {
     /// <summary>
-    /// Creates a CodeTransparencyClient with the specified endpoint and optional token environment variable.
+    /// Default scope used when acquiring an access token via DefaultAzureCredential.
     /// </summary>
-    /// <param name="endpoint">The Azure Code Transparency Service endpoint URL.</param>
-    /// <param name="tokenEnvVarName">Optional name of the environment variable containing the access token. 
-    /// If not specified, defaults to "MST_TOKEN". If the environment variable is not set, 
-    /// uses DefaultAzureCredential.</param>
+    private const string DefaultAzureCredentialScope = "https://confidential-ledger.azure.com/.default";
+
+    /// <summary>
+    /// Default name of the environment variable to read for an access token when no <c>--token-env</c>
+    /// override is supplied.
+    /// </summary>
+    private const string DefaultTokenEnvVarName = "MST_TOKEN";
+
+    /// <summary>
+    /// Pre-allocated single-element scope array for <see cref="DefaultAzureCredential"/> token requests.
+    /// Hoisted to <c>static readonly</c> so the array is not re-allocated on every invocation.
+    /// </summary>
+    private static readonly string[] DefaultAzureCredentialScopes = new[] { DefaultAzureCredentialScope };
+
+    /// <summary>
+    /// Creates a <see cref="CodeTransparencyClient"/> with the specified endpoint and authentication mode.
+    /// </summary>
+    /// <param name="endpoint">The Microsoft's Signing Transparency (MST) service endpoint URL.</param>
+    /// <param name="tokenEnvVarName">
+    /// Optional name of the environment variable containing an access token. When the caller supplies
+    /// this value explicitly (non-whitespace), the variable MUST contain a non-whitespace value or the
+    /// call fails fast with <see cref="InvalidOperationException"/>. When <c>null</c> or whitespace,
+    /// the helper consults <c>MST_TOKEN</c> as a non-fatal default.
+    /// </param>
+    /// <param name="useAzureAuth">
+    /// When <c>true</c>, fall back to <see cref="DefaultAzureCredential"/> to acquire a token if no
+    /// access token is found via the environment variable. When <c>false</c> (default), the client is
+    /// constructed without credentials so calls reach the endpoint anonymously — appropriate for
+    /// unauthenticated MST instances such as test ledgers.
+    /// </param>
+    /// <param name="logger">
+    /// Optional logger. When supplied, the helper emits a verbose-level message indicating which
+    /// authentication path was selected (token / azure-auth / anonymous). The token contents are
+    /// never logged.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token for async operations.</param>
-    /// <returns>A configured CodeTransparencyClient instance.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when token environment variable is empty or invalid.</exception>
-    public static async Task<CodeTransparencyClient> CreateClientAsync(string endpoint, string? tokenEnvVarName, CancellationToken cancellationToken = default)
+    /// <returns>A configured <see cref="CodeTransparencyClient"/> instance.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="tokenEnvVarName"/> is supplied explicitly but the named environment
+    /// variable is missing, empty, or whitespace.
+    /// </exception>
+    public static async Task<CodeTransparencyClient> CreateClientAsync(
+        string endpoint,
+        string? tokenEnvVarName,
+        bool useAzureAuth,
+        IPluginLogger? logger = null,
+        CancellationToken cancellationToken = default)
     {
-        Uri uri = new Uri(endpoint);
-        CodeTransparencyClientOptions clientOptions = new CodeTransparencyClientOptions();
+        Uri uri = new(endpoint);
+        CodeTransparencyClientOptions clientOptions = new();
         clientOptions.ConfigureMstPerformanceOptimizations();
 
-        // Use the specified environment variable name or default to MST_TOKEN
-        string envVarName = tokenEnvVarName ?? "MST_TOKEN";
+        bool tokenEnvVarExplicitlyRequested = !string.IsNullOrWhiteSpace(tokenEnvVarName);
+        string envVarName = tokenEnvVarExplicitlyRequested ? tokenEnvVarName! : DefaultTokenEnvVarName;
         string? token = Environment.GetEnvironmentVariable(envVarName);
 
-        if (!string.IsNullOrEmpty(token))
+        if (!string.IsNullOrWhiteSpace(token))
         {
-            // Use the access token from the environment variable
-            // Use AzureKeyCredential for access tokens as documented in:
+            // Use the access token from the environment variable.
+            // AzureKeyCredential is the documented pattern for static tokens, see:
             // https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/confidentialledger/Azure.Security.CodeTransparency/samples/Sample3_UseYourCredentials.md
-            AzureKeyCredential credential = new AzureKeyCredential(token);
+            logger?.LogVerbose($"MST auth: using access token from environment variable '{envVarName}'");
+            AzureKeyCredential credential = new(token);
             return new CodeTransparencyClient(uri, credential, clientOptions);
         }
 
-        // Use default Azure credential (managed identity, Azure CLI, etc.) when no token is provided
-        // Note: CodeTransparencyClient constructor only accepts TokenCredential if using DefaultAzureCredential
-        // directly, but the pattern from Azure docs uses AzureKeyCredential with retrieved tokens
-        DefaultAzureCredential defaultCred = new DefaultAzureCredential(); // CodeQL [SM05137] This is non-production testing code which is not deployed.
-        string[] defaultScopes = new[] { "https://confidential-ledger.azure.com/.default" };
-        AccessToken defaultToken = await defaultCred.GetTokenAsync(new TokenRequestContext(defaultScopes), cancellationToken);
-        return new CodeTransparencyClient(uri, new AzureKeyCredential(defaultToken.Token), clientOptions);
+        if (tokenEnvVarExplicitlyRequested)
+        {
+            throw new InvalidOperationException(
+                $"--token-env was set to '{envVarName}' but the environment variable is missing, empty, or whitespace.");
+        }
+
+        if (useAzureAuth)
+        {
+            // Acquire a token via the Azure default credential chain (CLI, MSI, VS, etc.).
+            logger?.LogVerbose("MST auth: using Azure DefaultAzureCredential (--azure-auth)");
+            DefaultAzureCredential defaultCred = new(); // CodeQL [SM05137] This is non-production testing code which is not deployed.
+            AccessToken defaultToken = await defaultCred.GetTokenAsync(new TokenRequestContext(DefaultAzureCredentialScopes), cancellationToken);
+            return new CodeTransparencyClient(uri, new AzureKeyCredential(defaultToken.Token), clientOptions);
+        }
+
+        // No credential supplied — construct an anonymous client. Appropriate for unauthenticated
+        // MST instances (e.g., test ledgers). The SDK omits the bearer auth policy when no
+        // credential is provided, so no Authorization header is sent.
+        logger?.LogVerbose("MST auth: anonymous (no credentials sent). Pass --token-env or --azure-auth if the endpoint requires auth.");
+        return new CodeTransparencyClient(uri, clientOptions);
     }
 }
 

--- a/CoseSignTool.MST.Plugin/CodeTransparencyClientHelper.cs
+++ b/CoseSignTool.MST.Plugin/CodeTransparencyClientHelper.cs
@@ -92,7 +92,7 @@ internal static class CodeTransparencyClientHelper
             // Acquire a token via the Azure default credential chain (CLI, MSI, VS, etc.).
             logger?.LogVerbose("MST auth: using Azure DefaultAzureCredential (--azure-auth)");
             DefaultAzureCredential defaultCred = new(); // CodeQL [SM05137] This is non-production testing code which is not deployed.
-            AccessToken defaultToken = await defaultCred.GetTokenAsync(new TokenRequestContext(DefaultAzureCredentialScopes), cancellationToken);
+            AccessToken defaultToken = await defaultCred.GetTokenAsync(new TokenRequestContext(DefaultAzureCredentialScopes), cancellationToken).ConfigureAwait(false);
             return new CodeTransparencyClient(uri, new AzureKeyCredential(defaultToken.Token), clientOptions);
         }
 

--- a/CoseSignTool.MST.Plugin/CoseSignTool.MST.Plugin.csproj
+++ b/CoseSignTool.MST.Plugin/CoseSignTool.MST.Plugin.csproj
@@ -55,7 +55,6 @@
   <ItemGroup>
     <ProjectReference Include="..\CoseSignTool.Abstractions\CoseSignTool.Abstractions.csproj" />
     <ProjectReference Include="..\CoseSign1.Transparent.MST\CoseSign1.Transparent.MST.csproj" />
-    <ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
   </ItemGroup>
 
 </Project>

--- a/CoseSignTool.MST.Plugin/MstCommandBase.cs
+++ b/CoseSignTool.MST.Plugin/MstCommandBase.cs
@@ -24,11 +24,25 @@ public abstract class MstCommandBase : PluginCommandBase
     {
         { "endpoint", "The Microsoft's Signing Transparency (MST) service endpoint URL" },
         { "token-env", "The name of the environment variable containing the access token (default: MST_TOKEN)" },
+        { "azure-auth", "When set, fall back to Azure DefaultAzureCredential (CLI/MSI/etc.) if no access token is provided. Default behaviour is anonymous (suitable for unauthenticated MST instances)." },
         { "payload", "The file path to the payload file" },
         { "signature", "The file path to the COSE Sign1 signature file" },
         { "output", "The file path where the result will be written (optional)" },
         { "timeout", "Timeout in seconds for the operation (default: 30)" }
     };
+
+    /// <summary>
+    /// Pre-allocated single-element collection of boolean option names exposed by all MST commands.
+    /// Hoisted to <c>static readonly</c> so each command instance does not allocate its own array.
+    /// </summary>
+    private static readonly string[] BooleanOptionsArray = new[] { "azure-auth" };
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <c>azure-auth</c> is a boolean flag that opts into Azure <c>DefaultAzureCredential</c> when no
+    /// explicit access token is supplied. It can be passed without a value (e.g., <c>--azure-auth</c>).
+    /// </remarks>
+    public override IReadOnlyCollection<string> BooleanOptions => BooleanOptionsArray;
 
     /// <summary>
     /// Validates common parameters and returns parsed timeout value.
@@ -166,6 +180,12 @@ public abstract class MstCommandBase : PluginCommandBase
             FileNotFoundException fileEx => 
                 HandleError($"File not found - {fileEx.Message}", PluginExitCode.UserSpecifiedFileNotFound, logger),
             
+            // Auth-configuration errors (e.g., explicit --token-env name with missing/whitespace value)
+            // surface as InvalidOperationException from CodeTransparencyClientHelper. Map them to
+            // InvalidArgumentValue so the operator gets a semantic exit code rather than UnknownError.
+            InvalidOperationException invOpEx =>
+                HandleError(invOpEx.Message, PluginExitCode.InvalidArgumentValue, logger),
+
             OperationCanceledException when cancellationToken.IsCancellationRequested => 
                 HandleError("Operation was cancelled.", PluginExitCode.UnknownError, logger),
             
@@ -188,11 +208,13 @@ public abstract class MstCommandBase : PluginCommandBase
     /// </summary>
     /// <param name="endpoint">The CTS endpoint URL.</param>
     /// <param name="tokenEnvVarName">Name of the environment variable containing the access token.</param>
+    /// <param name="useAzureAuth">When true, fall back to Azure DefaultAzureCredential if no token is set.</param>
+    /// <param name="logger">Optional logger used to record which auth path was selected.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Configured CodeTransparencyClient.</returns>
-    protected static Task<CodeTransparencyClient> CreateCtsClient(string endpoint, string? tokenEnvVarName, CancellationToken cancellationToken)
+    protected static Task<CodeTransparencyClient> CreateCtsClient(string endpoint, string? tokenEnvVarName, bool useAzureAuth, IPluginLogger? logger, CancellationToken cancellationToken)
     {
-        return CodeTransparencyClientHelper.CreateClientAsync(endpoint, tokenEnvVarName, cancellationToken);
+        return CodeTransparencyClientHelper.CreateClientAsync(endpoint, tokenEnvVarName, useAzureAuth, logger, cancellationToken);
     }
 
     /// <summary>
@@ -217,6 +239,7 @@ public abstract class MstCommandBase : PluginCommandBase
             // Get optional parameters
             string? tokenEnvVarName = GetOptionalValue(configuration, "token-env");
             string? outputPath = GetOptionalValue(configuration, "output");
+            bool useAzureAuth = GetBooleanFlag(configuration, "azure-auth");
 
             // Validate common parameters
             PluginExitCode validationResult = ValidateCommonParameters(configuration, out int timeoutSeconds, Logger);
@@ -248,11 +271,14 @@ public abstract class MstCommandBase : PluginCommandBase
                 return readResult;
             }
 
+            // Honour --timeout for the entire operation including auth acquisition (DefaultAzureCredential
+            // can hang on developer credentials, so the client construction must respect the timeout too).
+            using CancellationTokenSource combinedCts = CreateTimeoutCancellationToken(timeoutSeconds, cancellationToken);
+
             // Create CTS client
-            CodeTransparencyClient client = await CreateCtsClient(endpoint, tokenEnvVarName, cancellationToken);
+            CodeTransparencyClient client = await CreateCtsClient(endpoint, tokenEnvVarName, useAzureAuth, Logger, combinedCts.Token);
 
             // Execute the specific operation
-            using CancellationTokenSource combinedCts = CreateTimeoutCancellationToken(timeoutSeconds, cancellationToken);
             (PluginExitCode exitCode, object? result) operationResult = await ExecuteSpecificOperation(
                 client, message, signatureBytes, endpoint, payloadPath, signaturePath, 
                 configuration, combinedCts.Token);
@@ -316,8 +342,10 @@ public abstract class MstCommandBase : PluginCommandBase
                $"  --signature     The file path to the COSE Sign1 signature file{Environment.NewLine}" +
                $"{Environment.NewLine}" +
                $"Optional arguments:{Environment.NewLine}" +
-               $"  --token-env     Name of environment variable containing access token{Environment.NewLine}" +
-               $"                  (default: MST_TOKEN, uses default Azure credential if not specified){Environment.NewLine}" +
+               $"  --token-env     Name of environment variable containing access token (default: MST_TOKEN){Environment.NewLine}" +
+               $"  --azure-auth    Opt into Azure DefaultAzureCredential (CLI / managed identity / etc.){Environment.NewLine}" +
+               $"                  when no access token is supplied. Default behaviour is anonymous,{Environment.NewLine}" +
+               $"                  which is appropriate for unauthenticated MST instances (test ledgers).{Environment.NewLine}" +
                $"  --output        File path where {verb} result will be written{Environment.NewLine}";
     }
 

--- a/CoseSignTool.MST.Plugin/MstCommandBase.cs
+++ b/CoseSignTool.MST.Plugin/MstCommandBase.cs
@@ -96,7 +96,7 @@ public abstract class MstCommandBase : PluginCommandBase
     {
         try
         {
-            byte[] signatureBytes = await File.ReadAllBytesAsync(signaturePath, cancellationToken);
+            byte[] signatureBytes = await File.ReadAllBytesAsync(signaturePath, cancellationToken).ConfigureAwait(false);
             CoseSign1Message message = CoseMessage.DecodeSign1(signatureBytes);
             return (message, signatureBytes, PluginExitCode.Success);
         }
@@ -135,7 +135,7 @@ public abstract class MstCommandBase : PluginCommandBase
     protected static async Task WriteJsonResult(string outputPath, object result, CancellationToken cancellationToken, IPluginLogger? logger = null)
     {
         string jsonOutput = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
-        await File.WriteAllTextAsync(outputPath, jsonOutput, cancellationToken);
+        await File.WriteAllTextAsync(outputPath, jsonOutput, cancellationToken).ConfigureAwait(false);
         logger?.LogInformation($"Result written to: {outputPath}");
     }
 
@@ -265,7 +265,7 @@ public abstract class MstCommandBase : PluginCommandBase
             }
 
             // Read and decode COSE message
-            (CoseSign1Message message, byte[] signatureBytes, PluginExitCode readResult) = await ReadAndDecodeCoseMessage(signaturePath, cancellationToken, Logger);
+            (CoseSign1Message message, byte[] signatureBytes, PluginExitCode readResult) = await ReadAndDecodeCoseMessage(signaturePath, cancellationToken, Logger).ConfigureAwait(false);
             if (readResult != PluginExitCode.Success || message == null)
             {
                 return readResult;
@@ -276,17 +276,17 @@ public abstract class MstCommandBase : PluginCommandBase
             using CancellationTokenSource combinedCts = CreateTimeoutCancellationToken(timeoutSeconds, cancellationToken);
 
             // Create CTS client
-            CodeTransparencyClient client = await CreateCtsClient(endpoint, tokenEnvVarName, useAzureAuth, Logger, combinedCts.Token);
+            CodeTransparencyClient client = await CreateCtsClient(endpoint, tokenEnvVarName, useAzureAuth, Logger, combinedCts.Token).ConfigureAwait(false);
 
             // Execute the specific operation
             (PluginExitCode exitCode, object? result) operationResult = await ExecuteSpecificOperation(
                 client, message, signatureBytes, endpoint, payloadPath, signaturePath, 
-                configuration, combinedCts.Token);
+                configuration, combinedCts.Token).ConfigureAwait(false);
 
             // Write output if requested
             if (!string.IsNullOrEmpty(outputPath) && operationResult.result != null)
             {
-                await WriteJsonResult(outputPath, operationResult.result, cancellationToken, Logger);
+                await WriteJsonResult(outputPath, operationResult.result, cancellationToken, Logger).ConfigureAwait(false);
             }
 
             return operationResult.exitCode;

--- a/CoseSignTool.MST.Plugin/RegisterCommand.cs
+++ b/CoseSignTool.MST.Plugin/RegisterCommand.cs
@@ -61,7 +61,7 @@ public class RegisterCommand : MstCommandBase
 
         Logger.LogVerbose("Calling MakeTransparentAsync...");
         // Register with the transparency service
-        CoseSign1Message result = await transparencyService.MakeTransparentAsync(message, cancellationToken);
+        CoseSign1Message result = await transparencyService.MakeTransparentAsync(message, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation("Registration completed successfully.");
 

--- a/CoseSignTool.MST.Plugin/VerifyCommand.cs
+++ b/CoseSignTool.MST.Plugin/VerifyCommand.cs
@@ -109,15 +109,15 @@ public class VerifyCommand : MstCommandBase
         {
             Logger.LogVerbose($"Verifying with specific receipt from: {receiptPath}");
             // Verify with a specific receipt
-            byte[] receipt = await File.ReadAllBytesAsync(receiptPath, cancellationToken);
+            byte[] receipt = await File.ReadAllBytesAsync(receiptPath, cancellationToken).ConfigureAwait(false);
             Logger.LogVerbose($"Receipt size: {receipt.Length} bytes");
-            isValid = await transparencyService.VerifyTransparencyAsync(message, receipt, cancellationToken);
+            isValid = await transparencyService.VerifyTransparencyAsync(message, receipt, cancellationToken).ConfigureAwait(false);
         }
         else
         {
             Logger.LogVerbose("Verifying using embedded transparency information");
             // Verify using embedded transparency information
-            isValid = await message.VerifyTransparencyAsync(transparencyService, cancellationToken);
+            isValid = await message.VerifyTransparencyAsync(transparencyService, cancellationToken).ConfigureAwait(false);
         }
 
         if (isValid)

--- a/CoseSignTool/CoseSignTool.csproj
+++ b/CoseSignTool/CoseSignTool.csproj
@@ -77,6 +77,7 @@
     <ItemGroup>
         <ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
         <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
+        <ProjectReference Include="..\CoseSign1.Certificates.AzureArtifactSigning\CoseSign1.Certificates.AzureArtifactSigning.csproj" />
         <ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
         <ProjectReference Include="..\CoseSign1.Transparent.MST\CoseSign1.Transparent.MST.csproj" />
         <ProjectReference Include="..\CoseSignTool.Abstractions\CoseSignTool.Abstractions.csproj" />

--- a/CoseSignTool/CoseSignTool.csproj
+++ b/CoseSignTool/CoseSignTool.csproj
@@ -77,9 +77,7 @@
     <ItemGroup>
         <ProjectReference Include="..\CoseHandler\CoseHandler.csproj" />
         <ProjectReference Include="..\CoseSign1.Certificates\CoseSign1.Certificates.csproj" />
-        <ProjectReference Include="..\CoseSign1.Certificates.AzureArtifactSigning\CoseSign1.Certificates.AzureArtifactSigning.csproj" />
         <ProjectReference Include="..\CoseSign1.Headers\CoseSign1.Headers.csproj" />
-        <ProjectReference Include="..\CoseSign1.Transparent.MST\CoseSign1.Transparent.MST.csproj" />
         <ProjectReference Include="..\CoseSignTool.Abstractions\CoseSignTool.Abstractions.csproj" />
     </ItemGroup>
 

--- a/CoseSignTool/CoseSignTool.csproj
+++ b/CoseSignTool/CoseSignTool.csproj
@@ -108,11 +108,13 @@
         </ItemGroup>
         
         <!-- For subdirectory isolation: Copy ALL plugin files to create self-contained plugin directories -->
-        <!-- Exclude only .NET framework assemblies (System.*, mscorlib, netstandard, Microsoft.CSharp, etc.) to avoid duplication -->
+        <!-- Exclude only true .NET BCL assemblies that ship with the runtime. Do NOT strip System.*
+             generally — out-of-band NuGet packages with System.* names (System.ClientModel,
+             System.Memory.Data, System.IO.Pipelines, System.Text.Json polyfills, etc.) are
+             legitimate plugin-private dependencies that must be deployed alongside the plugin. -->
         <ItemGroup>
             <PluginSpecificFiles Include="@(AllPluginFiles)" 
-                Condition="!$([System.String]::new('%(Filename)').StartsWith('System.')) 
-                    AND '%(Filename)' != 'mscorlib' 
+                Condition="'%(Filename)' != 'mscorlib' 
                     AND '%(Filename)' != 'netstandard' 
                     AND '%(Filename)' != 'Microsoft.CSharp' 
                     AND '%(Filename)' != 'WindowsBase' 

--- a/CoseSignTool/SignCommand.cs
+++ b/CoseSignTool/SignCommand.cs
@@ -978,10 +978,13 @@ public class SignCommand : CoseCommand
         // Note: We could pass a logger here if we had one available
         ICoseSigningKeyProvider provider = plugin.CreateProvider(configuration, logger: null);
 
-        // If the provider is a certificate-based provider, set the EnableScittCompliance flag
-        if (provider is CoseSign1.Certificates.CertificateCoseSigningKeyProvider certProvider)
+        // Apply SCITT compliance opt-in via the shared capability interface so the host does not
+        // depend on the concrete CertificateCoseSigningKeyProvider type. This keeps
+        // CoseSign1.Certificates plugin-local in AssemblyLoadContext isolation scenarios — only
+        // ISupportsScittCompliance (in CoseSign1.Abstractions) needs to cross the boundary.
+        if (provider is ISupportsScittCompliance scittProvider)
         {
-            certProvider.EnableScittCompliance = EnableScittCompliance;
+            scittProvider.EnableScittCompliance = EnableScittCompliance;
         }
 
         return provider;

--- a/docs/MST.md
+++ b/docs/MST.md
@@ -19,31 +19,54 @@ The MST plugin is automatically included with CoseSignTool releases using the en
 
 ## Authentication
 
-The plugin supports flexible authentication methods with automatic fallback:
+The plugin supports three authentication modes. The default is **anonymous** (suitable for unauthenticated MST instances such as test ledgers). Bearer token and Azure-credential paths are opt-in.
 
-### 1. Environment Variable Authentication (Recommended)
+**Precedence:** explicit access token (env var) > `--azure-auth` (DefaultAzureCredential) > anonymous.
 
-Set an access token in an environment variable:
+### 1. Anonymous (default)
+
+When no access token is supplied and `--azure-auth` is not passed, the plugin constructs the client without credentials. No `Authorization` header is sent.
 
 ```bash
-# Using the default environment variable
+# Anonymous registration against an unauthenticated test ledger
+CoseSignTool mst_register \
+    --endpoint https://your-mst-test-instance.confidential-ledger.azure.com \
+    --payload myfile.txt \
+    --signature myfile.txt.cose
+```
+
+### 2. Environment Variable Authentication
+
+Set an access token in an environment variable. When `--token-env <NAME>` is supplied explicitly, the named variable **must** contain a non-whitespace value or the command fails fast.
+
+```bash
+# Using the default environment variable (MST_TOKEN)
 export MST_TOKEN="your-access-token"
 
 # Using a custom environment variable
 export MY_MST_TOKEN="your-access-token"
+CoseSignTool mst_register ... --token-env MY_MST_TOKEN
 ```
 
-### 2. Azure DefaultCredential (Fallback)
+### 3. Azure DefaultCredential (`--azure-auth`)
 
-When no token is provided, the plugin automatically falls back to Azure DefaultCredential, which supports:
+Pass the `--azure-auth` flag to opt into [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential), which supports:
 - Azure CLI credentials (`az login`)
 - Managed Identity (in Azure environments)
 - Azure PowerShell credentials
 - Environment variables (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`)
-- Visual Studio credentials
-- VS Code credentials
+- Visual Studio / VS Code credentials
 
-> **⚠️ Production Security Note**: When deploying to production environments, create an environment variable named `AZURE_TOKEN_CREDENTIALS` and set its value to `"prod"`. This excludes developer tool credentials from the credential chain, ensuring only production-appropriate credentials are used. This is required when using Azure.Identity version 1.14.0 or later. For more information, see the [DefaultAzureCredential overview](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+```bash
+# Requires az login or other Azure authentication
+CoseSignTool mst_register \
+    --endpoint https://your-mst-instance.azure.com \
+    --payload myfile.txt \
+    --signature myfile.txt.cose \
+    --azure-auth
+```
+
+> **⚠️ Production Security Note**: When using `--azure-auth` in production, create an environment variable named `AZURE_TOKEN_CREDENTIALS` and set its value to `"prod"`. This excludes developer tool credentials from the credential chain, ensuring only production-appropriate credentials are used. This is required when using Azure.Identity version 1.14.0 or later. See the [DefaultAzureCredential overview](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 ```bash
 # In production environments, set this environment variable:
@@ -64,14 +87,23 @@ CoseSignTool mst_register [OPTIONS]
 #### Required Options
 - `--endpoint` - Azure CTS service endpoint URL
 - `--payload` - Path to the payload file
-- `--signature` - Path to the COSE Sign1 signature file
+- `--signature` - Path to the COSE Sign1 signature file (must be **embedded** — MST rejects detached payloads)
 
 #### Optional Options
-- `--token-env-var` - Environment variable name containing the access token (default: `MST_TOKEN`)
+- `--token-env` - Environment variable name containing the access token (default: `MST_TOKEN`). When passed explicitly, the named variable **must** be non-empty.
+- `--azure-auth` - Opt into Azure `DefaultAzureCredential` when no token is supplied. Default is anonymous.
 - `--output` - Output file path for the registration result
-- `--timeout` - Operation timeout in seconds (default: 30)
+- `--timeout` - Operation timeout in seconds (default: 30). The timeout covers credential acquisition as well as the registration call.
 
 #### Examples
+
+**Anonymous (test ledger):**
+```bash
+CoseSignTool mst_register \
+    --endpoint https://aasmsttest.confidential-ledger.azure.com \
+    --payload myfile.txt \
+    --signature myfile.txt.cose
+```
 
 **Using default environment variable:**
 ```bash
@@ -89,7 +121,7 @@ CoseSignTool mst_register \
     --endpoint https://your-mst-instance.azure.com \
     --payload myfile.txt \
     --signature myfile.txt.cose \
-    --token-env-var MY_MST_TOKEN
+    --token-env MY_MST_TOKEN
 ```
 
 **Using Azure DefaultCredential:**
@@ -126,10 +158,11 @@ CoseSignTool mst_verify [OPTIONS]
 - `--signature` - Path to the COSE Sign1 signature file
 
 #### Optional Options
-- `--token-env-var` - Environment variable name containing the access token (default: `MST_TOKEN`)
+- `--token-env` - Environment variable name containing the access token (default: `MST_TOKEN`). When passed explicitly, the named variable **must** be non-empty.
+- `--azure-auth` - Opt into Azure `DefaultAzureCredential` when no token is supplied. Default is anonymous.
 - `--output` - Output file path for the verification result
 - `--receipt` - Path to a specific receipt file to use for verification
-- `--timeout` - Operation timeout in seconds (default: 30)
+- `--timeout` - Operation timeout in seconds (default: 30). The timeout covers credential acquisition as well as the verification call.
 - `--authorized-domains` - Comma-separated list of authorized issuer domains for receipt verification
 - `--authorized-receipt-behavior` - Behavior for receipts from authorized domains:
   - `VerifyAnyMatching` - At least one receipt from any authorized domain must be valid

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1231,7 +1231,7 @@ CoseSignTool mst_register \
     --endpoint https://your-cts-instance.azure.com \
     --payload myfile.txt \
     --signature myfile.txt.cose \
-    --token-env-var MY_MST_TOKEN
+    --token-env MY_MST_TOKEN
 
 # Verify a signature with Microsoft's Signing Transparency (MST)
 export MST_TOKEN="your-access-token"
@@ -1241,25 +1241,36 @@ CoseSignTool mst_verify \
     --signature myfile.txt.cose \
     --receipt receipt.json
 
-# Using Azure DefaultCredential when no token is provided
+# Anonymous registration against an unauthenticated MST instance (default)
+CoseSignTool mst_register \
+    --endpoint https://your-mst-test-instance.confidential-ledger.azure.com \
+    --payload myfile.txt \
+    --signature myfile.txt.cose
+
+# Using Azure DefaultCredential (opt-in via --azure-auth)
 CoseSignTool mst_register \
     --endpoint https://your-cts-instance.azure.com \
     --payload myfile.txt \
-    --signature myfile.txt.cose
+    --signature myfile.txt.cose \
+    --azure-auth
 ```
 
 ### Authentication
 
-The MST plugin supports multiple authentication methods with the following priority:
+The MST plugin supports three authentication modes with the following precedence (highest first):
 
 1. **Environment Variable Token**: Uses an access token from an environment variable
-   - `--token-env-var` specifies the environment variable name
-   - If not specified, defaults to `MST_TOKEN`
+   - `--token-env` specifies the environment variable name
+   - If `--token-env` is not specified, defaults to `MST_TOKEN`
+   - When `--token-env` is supplied explicitly, the named variable **must** contain a non-whitespace value or the command fails fast
    - This is the recommended approach for CI/CD environments
 
-2. **Azure DefaultCredential**: Falls back to Azure DefaultCredential when no token is found
+2. **Azure DefaultCredential** (opt-in via `--azure-auth`): Falls back to Azure DefaultCredential when no token is provided
    - Automatically uses available Azure credentials (managed identity, Azure CLI, etc.)
    - Ideal for local development and Azure-hosted environments
+
+3. **Anonymous** (default): The client is constructed without credentials; no `Authorization` header is sent
+   - Appropriate for unauthenticated MST instances such as test ledgers
 
 #### Authentication Examples
 
@@ -1270,11 +1281,14 @@ CoseSignTool mst_register --endpoint https://your-cts-instance.azure.com --paylo
 
 # Using custom environment variable
 export MY_CUSTOM_TOKEN="your-access-token"
-CoseSignTool mst_register --endpoint https://your-mst-instance.azure.com --payload file.txt --signature file.cose --token-env-var MY_CUSTOM_TOKEN
+CoseSignTool mst_register --endpoint https://your-mst-instance.azure.com --payload file.txt --signature file.cose --token-env MY_CUSTOM_TOKEN
 
-# Using Azure DefaultCredential (no token environment variable set)
+# Anonymous (unauthenticated test ledger; default behavior)
+CoseSignTool mst_register --endpoint https://aasmsttest.confidential-ledger.azure.com --payload file.txt --signature file.cose
+
+# Using Azure DefaultCredential (opt-in)
 # Requires Azure CLI login, managed identity, or other Azure credential
-CoseSignTool mst_register --endpoint https://your-cts-instance.azure.com --payload file.txt --signature file.cose
+CoseSignTool mst_register --endpoint https://your-cts-instance.azure.com --payload file.txt --signature file.cose --azure-auth
 ```
 
 ### Certificate Provider Plugin: Azure Artifact Signing


### PR DESCRIPTION
## Summary

Fixes three coupled bugs surfaced when running `mst_register` against an unauthenticated MST test ledger after AAS signing, then takes the architectural cleanup all the way down rather than working around the original ALC type-identity smell with another shared-prefix.

1. **`MissingMethodException` from cross-ALC type identity mismatch** — `CoseSign1.Transparent.MST.dll` was loaded in the host AssemblyLoadContext (shared `CoseSign1` prefix) but `Azure.Security.CodeTransparency` was plugin-local, so `CodeTransparencyClientOptions` had two distinct identities and `ConfigureMstPerformanceOptimizations` would not bind at runtime.
2. **Implicit `DefaultAzureCredential` fallback** broke against unauthenticated endpoints — silently fell back to `DefaultAzureCredential` when `MST_TOKEN` was unset, hanging on developer credentials or sending bogus tokens to test ledgers.
3. **AAS performance parity** with the MST plugin — interactive signing latency was unbounded by the SDK''s exponential back-off (800 ms × 3, ~5 s ceiling).

## Changes

### 1. Plugin AssemblyLoadContext — eliminate prefix-collision smell and host load-anchor coupling

> **Note** Section 1 was originally written for an interim fix that added Azure SDK prefixes to the shared list. The branch evolved to a structurally cleaner design in commits `d6afc6a` → `9daff95` → `fac4c58e`. The text below describes the FINAL implementation that ships in this PR. Updated in response to PR feedback.

The previous prefix-matching shared list (`"CoseSign1"`, `"CoseHandler"`, `"CoseIndirectSignature"`, plus `"Azure.*"` workarounds) had two real problems:

- **Prefix collision**: a hypothetical 3rd-party `CoseSign1Plus.dll` would have been silently absorbed into the host context.
- **Load-anchor coupling**: `CoseSignTool.csproj` carried `ProjectReferences` on `CoseSign1.Transparent.MST` and `CoseSign1.Certificates.AzureArtifactSigning` purely so the prefix match could find them. Verified zero `using` statements or call-sites from host code into either library — they existed in `bin\` only as load anchors.

The fix replaces prefix matching with an explicit, exact-name allow-list and lets the offending libraries become fully plugin-local:

| Concept | Before | After |
|---|---|---|
| Shared decision | Prefix `StartsWith` over `string[]` | Exact-name `HashSet<string>` + small framework prefix list |
| Repo-curated shared assemblies | `CoseSignTool.Abstractions`, `CoseHandler`, `CoseSign1`, `CoseIndirectSignature` (all loose prefixes) | `CoseSignTool.Abstractions`, `CoseSign1.Abstractions`, `CoseSign1.Headers` (exact names) |
| `CoseSign1.Transparent.MST` | Host-shared (host `ProjectReference` was the load anchor) | **Plugin-local** in MST plugin ALC |
| `CoseSign1.Certificates.AzureArtifactSigning` | Host-shared (host `ProjectReference` was the load anchor) | **Plugin-local** in AAS plugin ALC |
| `Azure.Core` / `Azure.Security.CodeTransparency` / `Azure.CodeSigning` / `Azure.Developer.ArtifactSigning` | Force-shared via prefix workaround | **Plugin-local** — they co-locate with their callers in the plugin ALC, so the type-identity bug is structurally impossible |
| Concrete `is CoseSign1.Certificates.CertificateCoseSigningKeyProvider` downcast in `SignCommand` | Required `CoseSign1.Certificates` to be host-shared | Replaced with `is ISupportsScittCompliance` (new shared interface in `CoseSign1.Abstractions`); concrete type can be plugin-local |
| `CertificateProviderPluginManager.LoadPluginFromAssembly` | `Assembly.LoadFrom` into the default ALC (no isolation) | Uses `PluginLoadContext` — AAS plugin gets the same isolation as MST and IndirectSignature |
| Plugin-deploy MSBuild target | Stripped all `System.*` files (broke `System.ClientModel` etc.) | Only true BCL names excluded (`mscorlib`, `netstandard`, `Microsoft.CSharp`, …) |
| `Load()` exception handler | Broad `catch (Exception)` | Filtered `catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not ThreadAbortException and not AccessViolationException)` — accepts every assembly-load failure mode (incl. surprise `InvalidOperationException` on macOS arm64) while letting truly fatal process-killers propagate; CodeQL `cs/catch-of-all-exceptions` does not flag filtered catches |

Net result of this section: **zero Azure SDK assemblies in the host bin**, full plugin isolation, no host process changes required to support new plugin-private deps, no prefix-collision risk for 3rd-party plugins.

### 2. MST auth contract (BREAKING)

`CodeTransparencyClientHelper.CreateClientAsync` precedence is now:

> explicit token env var (`--token-env` / `MST_TOKEN`) > `--azure-auth` > anonymous

- **Default = anonymous.** No `Authorization` header is sent. Appropriate for unauthenticated MST instances (test ledgers).
- **`--azure-auth`** is a new boolean flag that opts into `DefaultAzureCredential`.
- **Explicit `--token-env <NAME>`** with missing/whitespace value now throws `InvalidOperationException` (no silent downgrade).
- **Token-wins-over-flag.** When both `MST_TOKEN` and `--azure-auth` are set, the token is used (no DefaultAzureCredential acquisition).
- **Timeout coverage extended.** `--timeout` now wraps credential acquisition so `DefaultAzureCredential.GetTokenAsync` cannot exceed user-set timeouts.

### 3. AAS performance parity

New shared-library extension `CoseSign1.Certificates.AzureArtifactSigning.Extensions.AasClientOptionsExtensions` (mirrors the MST extension layout):

- `ConfigureAasPerformanceOptimizations(this CertificateProfileClientOptions)` — Fixed mode, 250 ms × 8 retries (vs SDK default Exponential 800 ms × 3, ~2 s vs ~5 s ceiling).
- `ConfigureAasSigningPerformance(taskRetryCount, taskTimeoutSeconds)` — tunable `AzSignContextOptions` factory; defaults match SDK baseline.

No retry-After header stripping (that is an MST-specific workaround for the ledger eventual-consistency window; AAS honours `Retry-After` correctly).

Wired into `AzureArtifactSigningCertificateProviderPlugin.CreateProvider`.

### 4. Code review follow-ups

- Applied `.ConfigureAwait(false)` to all 11 awaits in the MST plugin (matches the convention used in `CoseHandler.cs`, `MstTransparencyService.cs`, `MstPerformanceOptimizationPolicy.cs`). Resolves the ConfigureAwait review thread.
- Rewrote two `try { … } finally { …; consoleOutput.Dispose(); }` blocks to use `using` declarations (CodeQL `cs/missed-using-opportunity` alerts #879/#880).

## Tests

| Project | Status |
|---|---|
| `CoseSignTool.MST.Plugin.Tests` | 56/56 — rewrote `CodeTransparencyClientHelperTests` for the new auth contract; added `MstAzureAuthFlagWiringTests` (`--azure-auth` is in `Options` + `BooleanOptions` on both commands). `[DoNotParallelize]` + `[TestInitialize]`/`[TestCleanup]` snapshot/restore env vars for hermetic execution. |
| `CoseSign1.Certificates.AzureArtifactSigning.Tests` | 60/60 — new `AasClientOptionsExtensionsTests` covers default + override paths plus null-options guard. |
| `CoseSignTool.Abstractions.Tests` | 122/122 — replaced reflection-based `IsSharedFrameworkAssembly` tests with calls to the new public `PluginLoadContext.IsHostShared`. New tests cover: curated cross-boundary contracts, formerly-shared prefixes (now NOT shared), Azure SDK / Newtonsoft.Json (NOT shared), 3rd-party prefix-collision impostors (NOT shared), `System.*` resolution via default-context fallback, prefix-collision regression (`CoseSign1Plus.dll` loads plugin-locally), shared-name resolver-bypass guarantee. |
| `CoseSign1.Certificates.Tests` | 145/145 — new `ISupportsScittCompliance` cross-boundary contract tests (interface in `CoseSign1.Abstractions`, implemented by `CertificateCoseSigningKeyProvider`, round-trip toggling via the interface). |
| **Full solution** | **1205 passed, 5 skipped, 0 failed** (was 1195 baseline; +10 net from new tests). |

## Verification

End-to-end against the unauthenticated test ledger `https://aasmsttest.confidential-ledger.azure.com`:

```
CoseSignTool sign --PayloadFile sample.txt --SignatureFile sample.cose --EmbedPayload \
  --CertProvider azure-artifact-signing \
  --aas-endpoint https://wus.codesigning.azure.net \
  --aas-account-name testwus \
  --aas-cert-profile-name testWusCert1                                        # Exit 0

CoseSignTool mst_register --endpoint https://aasmsttest.confidential-ledger.azure.com \
  --payload sample.txt --signature sample.cose --output register.json         # Exit 0

CoseSignTool mst_verify --endpoint https://aasmsttest.confidential-ledger.azure.com \
  --payload sample.txt --signature sample.transparent.cose \
  --authorized-domains aasmsttest.confidential-ledger.azure.com               # Exit 0 (VALID)
```

`bin\` audit on the host confirms the architectural change: zero `Azure.*`, zero `CoseSign1.Transparent.MST`, zero `CoseSign1.Certificates.AzureArtifactSigning`. All Azure SDK and plugin-implementation assemblies live exclusively in `bin\plugins\<PluginName>\`.

## Breaking-change note

Users who previously relied on the implicit `DefaultAzureCredential` fallback (no `MST_TOKEN` set) must now pass `--azure-auth` explicitly. `docs/MST.md` and `docs/Plugins.md` are updated.

## Pre-PR review

Hey Jeromy / code-review pass surfaced one real bug pre-push: `CodeTransparencyClientHelperTests` mutated process-wide env vars without `[TestCleanup]`, leaking state if a test threw mid-flight. Fixed before pushing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>