### PR TITLE
[SECURITY] Fix CodeQL SM02196: suppress weak-hash warnings in negative test

### DIFF
--- a/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
+++ b/CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs
@@ -142,7 +142,7 @@ public class CoseHashEnvelopeTests
         CoseSign1MessageFactory factory = new();
         byte[] payload = Encoding.UTF8.GetBytes("payload-to-verify");
 
-        using HashAlgorithm legacyHasher = hashSuffix == "md5" ? MD5.Create() : SHA1.Create();
+        using HashAlgorithm legacyHasher = hashSuffix == "md5" ? MD5.Create() : SHA1.Create(); // CodeQL [SM02196] Negative test: MD5/SHA1 are intentional inputs verifying the library rejects legacy digest algorithms.
         byte[] payloadHash = legacyHasher.ComputeHash(payload);
 
         CoseSign1Message message = factory.CreateCoseSign1Message(


### PR DESCRIPTION
## Issue

Two CodeQL **SM02196** ("Weak cryptography", SDL `sdl-required`, important severity) findings flag the same line in `CoseIndirectSignature.Tests/CoseHashEnvelopeTests.cs:145`:

```csharp
using HashAlgorithm legacyHasher = hashSuffix == "md5" ? MD5.Create() : SHA1.Create();
```

- [SM02196 #1](https://codeql.microsoft.com/issues/8030b221-89c3-47fe-82b8-1d3b4efe7e0b?Context=sdl) — `SHA1.Create()` (col 81-94)
- [SM02196 #2](https://codeql.microsoft.com/issues/90b7129a-5cad-4d9c-8a3a-72afa0432bb8?Context=sdl) — `MD5.Create()` (col 66-78)

## Why suppression, not replacement

The test is named `SignatureMatchesRejectsLegacyDigestAlgorithms` and is parameterized on `[TestCase("md5")] [TestCase("sha1")]`. Its **explicit purpose** is to verify the library rejects MD5 and SHA1 as payload digest algorithms. Replacing them with SHA2 would defeat the test entirely — `SignatureMatches` would return `true` instead of `false` and the assertion would invert.

## Change

One line, suppression-only:

```diff
- using HashAlgorithm legacyHasher = hashSuffix == "md5" ? MD5.Create() : SHA1.Create();
+ using HashAlgorithm legacyHasher = hashSuffix == "md5" ? MD5.Create() : SHA1.Create(); // CodeQL [SM02196] Negative test: MD5/SHA1 are intentional inputs verifying the library rejects legacy digest algorithms.
```

The trailing `// CodeQL [SM02196] ...` format matches the repo's existing convention (see [`CoseSignTool/SignCommand.cs:1265`](https://github.com/microsoft/CoseSignTool/blob/main/CoseSignTool/SignCommand.cs#L1265) and L1307).

## Validation

- No behavioural change — comment-only edit.
- Subsequent CodeQL scan should clear both SM02196 findings on this line.

## Documentation

- [Microsoft.Security.Cryptography.10004 — Weak hash algorithms banned](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-remediation)
- [CodeQL `cs/weak-crypto`](https://codeql.microsoft.com/queries/querycard?QueryId=cs%2Fweak-crypto)