### PR TITLE
Clarify indirect SignatureMatches is a content-digest check; add ContentDigestMatches alias

### DIFF
--- a/CoseIndirectSignature.Tests/CoseSign1MessageIndirectSignatureExtensionsTests.cs
+++ b/CoseIndirectSignature.Tests/CoseSign1MessageIndirectSignatureExtensionsTests.cs
@@ -189,6 +189,82 @@ public class CoseSign1MessageIndirectSignatureExtensionsTests
     }
 
     [Test]
+    public void TestContentDigestMatchesStreamSuccess()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        IndirectSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+        using MemoryStream stream = new(randomBytes);
+
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+
+        // ContentDigestMatches is the intent-revealing alias for SignatureMatches and must agree with it.
+        // Reset the stream between calls because each call consumes it while hashing.
+        stream.Seek(0, SeekOrigin.Begin);
+        bool aliasResult = IndirectSignature.ContentDigestMatches(stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        bool legacyResult = IndirectSignature.SignatureMatches(stream);
+
+        aliasResult.Should().BeTrue();
+        aliasResult.Should().Be(legacyResult);
+    }
+
+    [Test]
+    public void TestContentDigestMatchesStreamFailure()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        IndirectSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        byte[] randomBytes2 = new byte[50];
+        new Random().NextBytes(randomBytes);
+        new Random().NextBytes(randomBytes2);
+        using MemoryStream stream = new(randomBytes2);
+
+        // test mismatched digest
+        CoseSign1Message? IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignature.ContentDigestMatches(stream).Should().BeFalse();
+
+        // test null object case
+        IndirectSignature = null;
+        CoseSign1MessageIndirectSignatureExtensions.ContentDigestMatches(IndirectSignature, stream).Should().BeFalse();
+    }
+
+    [Test]
+    public void TestContentDigestMatchesBytesSuccess()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        IndirectSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        new Random().NextBytes(randomBytes);
+
+        CoseSign1Message IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+
+        // ContentDigestMatches is the intent-revealing alias for SignatureMatches and must agree with it.
+        IndirectSignature.ContentDigestMatches(randomBytes).Should().BeTrue();
+        IndirectSignature.ContentDigestMatches(randomBytes).Should().Be(IndirectSignature.SignatureMatches(randomBytes));
+    }
+
+    [Test]
+    public void TestContentDigestMatchesBytesFailure()
+    {
+        ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();
+        IndirectSignatureFactory factory = new();
+        byte[] randomBytes = new byte[50];
+        byte[] randomBytes2 = new byte[50];
+        new Random().NextBytes(randomBytes);
+        new Random().NextBytes(randomBytes2);
+
+        // test mismatched digest
+        CoseSign1Message? IndirectSignature = factory.CreateIndirectSignature(randomBytes, coseSigningKeyProvider, "application/test.payload");
+        IndirectSignature.ContentDigestMatches(randomBytes2).Should().BeFalse();
+
+        // test null object case
+        IndirectSignature = null;
+        CoseSign1MessageIndirectSignatureExtensions.ContentDigestMatches(IndirectSignature, randomBytes).Should().BeFalse();
+    }
+
+    [Test]
     public void TestTryGetHashAlgorithmSuccess()
     {
         ICoseSigningKeyProvider coseSigningKeyProvider = SetupMockSigningKeyProvider();

--- a/CoseIndirectSignature/Extensions/CoseSign1MessageIndirectSignatureExtensions.cs
+++ b/CoseIndirectSignature/Extensions/CoseSign1MessageIndirectSignatureExtensions.cs
@@ -10,6 +10,14 @@ namespace CoseIndirectSignature.Extensions;
 /// </summary>
 /// <remarks>
 /// Logging is done through Trace.TraceError and Debug.WriteLine.
+/// <para>
+/// Security precondition: the members of this class inspect and compare values carried in the
+/// <see cref="CoseSign1Message"/> envelope (for example the embedded content hash and the protected
+/// headers). They do NOT verify the COSE_Sign1 signature. Callers are responsible for cryptographically
+/// verifying the signature and establishing trust in the signer (for example via <c>CoseHandler.Validate(...)</c>,
+/// or <c>VerifyEmbedded</c>/<c>VerifyDetached</c> together with an appropriate trust decision) BEFORE relying on
+/// any value read from the envelope.
+/// </para>
 /// </remarks>
 public static class CoseSign1MessageIndirectSignatureExtensions
 {
@@ -92,22 +100,74 @@ public static class CoseSign1MessageIndirectSignatureExtensions
     public static bool IsIndirectSignature(this CoseSign1Message? @this) => @this.TryGetIsCoseHashEnvelope() || @this.TryGetIsCoseHashVContentType() || @this.TryGetIndirectSignatureAlgorithm(out _);
 
     /// <summary>
-    /// Computes if the encoded Indirect signature within the CoseSign1Message object matches the given artifact stream.
+    /// Determines whether the hash embedded in the indirect signature matches the hash of the supplied artifact stream.
     /// </summary>
-    /// <param name="this">The CoseSign1Message to evaluate.</param>
+    /// <remarks>
+    /// This is a content-hash consistency check only: it recomputes the hash of <paramref name="artifactStream"/>
+    /// and compares it to the hash stored in the message <c>.Content</c>. It does NOT verify the COSE_Sign1 signature.
+    /// The embedded hash is only trustworthy once the signature has been verified, so the caller MUST cryptographically
+    /// verify the signature and establish trust in the signer (for example via <c>CoseHandler.Validate(...)</c>, or
+    /// <c>VerifyEmbedded</c> plus a trust decision) BEFORE calling this method. A <c>true</c> result from an unverified
+    /// message is meaningless because the embedded hash would itself be attacker-controllable.
+    /// </remarks>
+    /// <param name="this">The CoseSign1Message to evaluate. The caller must have already verified its signature and trust.</param>
     /// <param name="artifactStream">The artifact stream to evaluate.</param>
-    /// <returns>True if the Indirect signature in the CoseSign1Message matches the signature of the artifact stream; False otherwise.</returns>
+    /// <returns>True if the hash of <paramref name="artifactStream"/> matches the hash embedded in the (already verified) CoseSign1Message; False otherwise.</returns>
     public static bool SignatureMatches(this CoseSign1Message? @this, Stream artifactStream)
         => SignatureMatchesInternal(@this, artifactStream: artifactStream);
 
     /// <summary>
-    /// Computes if the encoded Indirect signature within the CoseSign1Message object matches the given artifact bytes.
+    /// Determines whether the hash embedded in the indirect signature matches the hash of the supplied artifact bytes.
     /// </summary>
-    /// <param name="this">The CoseSign1Message to evaluate.</param>
+    /// <remarks>
+    /// This is a content-hash consistency check only: it recomputes the hash of <paramref name="artifactBytes"/>
+    /// and compares it to the hash stored in the message <c>.Content</c>. It does NOT verify the COSE_Sign1 signature.
+    /// The embedded hash is only trustworthy once the signature has been verified, so the caller MUST cryptographically
+    /// verify the signature and establish trust in the signer (for example via <c>CoseHandler.Validate(...)</c>, or
+    /// <c>VerifyEmbedded</c> plus a trust decision) BEFORE calling this method. A <c>true</c> result from an unverified
+    /// message is meaningless because the embedded hash would itself be attacker-controllable.
+    /// </remarks>
+    /// <param name="this">The CoseSign1Message to evaluate. The caller must have already verified its signature and trust.</param>
     /// <param name="artifactBytes">The artifact bytes to evaluate.</param>
-    /// <returns>True if the Indirect signature in the CoseSign1Message matches the signature of the artifact bytes; False otherwise.</returns>
+    /// <returns>True if the hash of <paramref name="artifactBytes"/> matches the hash embedded in the (already verified) CoseSign1Message; False otherwise.</returns>
     public static bool SignatureMatches(this CoseSign1Message? @this, ReadOnlyMemory<byte> artifactBytes)
         => SignatureMatchesInternal(@this, artifactBytes: artifactBytes);
+
+    /// <summary>
+    /// Determines whether the content digest embedded in the indirect signature matches the digest of the supplied artifact stream.
+    /// </summary>
+    /// <remarks>
+    /// This is the intent-revealing alias for <c>SignatureMatches(CoseSign1Message, Stream)</c>. The word "Signature" in
+    /// <c>SignatureMatches</c> refers to the indirect signature artifact rather than the cryptographic COSE_Sign1 signature,
+    /// which is easy to misread; <c>ContentDigestMatches</c> makes the intent explicit. Like <c>SignatureMatches</c>, this is a
+    /// content-digest consistency check only: it recomputes the digest of <paramref name="artifactStream"/> and compares it to
+    /// the digest stored in the message <c>.Content</c>. It does NOT verify the COSE_Sign1 signature, so the caller MUST
+    /// cryptographically verify the signature and establish trust in the signer (for example via <c>CoseHandler.Validate(...)</c>,
+    /// or <c>VerifyEmbedded</c> plus a trust decision) BEFORE calling this method.
+    /// </remarks>
+    /// <param name="this">The CoseSign1Message to evaluate. The caller must have already verified its signature and trust.</param>
+    /// <param name="artifactStream">The artifact stream to evaluate.</param>
+    /// <returns>True if the digest of <paramref name="artifactStream"/> matches the digest embedded in the (already verified) CoseSign1Message; False otherwise.</returns>
+    public static bool ContentDigestMatches(this CoseSign1Message? @this, Stream artifactStream)
+        => @this.SignatureMatches(artifactStream);
+
+    /// <summary>
+    /// Determines whether the content digest embedded in the indirect signature matches the digest of the supplied artifact bytes.
+    /// </summary>
+    /// <remarks>
+    /// This is the intent-revealing alias for <c>SignatureMatches(CoseSign1Message, ReadOnlyMemory&lt;byte&gt;)</c>. The word
+    /// "Signature" in <c>SignatureMatches</c> refers to the indirect signature artifact rather than the cryptographic COSE_Sign1
+    /// signature, which is easy to misread; <c>ContentDigestMatches</c> makes the intent explicit. Like <c>SignatureMatches</c>,
+    /// this is a content-digest consistency check only: it recomputes the digest of <paramref name="artifactBytes"/> and compares
+    /// it to the digest stored in the message <c>.Content</c>. It does NOT verify the COSE_Sign1 signature, so the caller MUST
+    /// cryptographically verify the signature and establish trust in the signer (for example via <c>CoseHandler.Validate(...)</c>,
+    /// or <c>VerifyEmbedded</c> plus a trust decision) BEFORE calling this method.
+    /// </remarks>
+    /// <param name="this">The CoseSign1Message to evaluate. The caller must have already verified its signature and trust.</param>
+    /// <param name="artifactBytes">The artifact bytes to evaluate.</param>
+    /// <returns>True if the digest of <paramref name="artifactBytes"/> matches the digest embedded in the (already verified) CoseSign1Message; False otherwise.</returns>
+    public static bool ContentDigestMatches(this CoseSign1Message? @this, ReadOnlyMemory<byte> artifactBytes)
+        => @this.SignatureMatches(artifactBytes);
 
     /// <summary>
     /// Computes if the encoded Indirect signature within the CoseSign1Message object matches the given artifact bytes or artifact stream.

--- a/docs/CoseIndirectSignature.md
+++ b/docs/CoseIndirectSignature.md
@@ -29,6 +29,13 @@ CoseSign1Message indirectSignature = factory.CreateIndirectSignature(payload: ra
 ## Validation
 To help with validation of IndirectSignatures which are embedded within a CoseSign1Message object, [CoseSign1MessageIndirectSignatureExtensions](https://github.com/microsoft/CoseSignTool/tree/main/CoseIndirectSignature/Extensions/CoseSign1MessageIndirectSignatureExtensions.cs) C# extension class is provided to add a `SignatureMatches(...)` overload that accepts **Stream** or **Byte[]** content.
 
+> [!IMPORTANT]
+> `SignatureMatches(...)` performs a **content-hash consistency check only** &mdash; it recomputes the hash of the supplied artifact and compares it to the hash embedded in the message `.Content`. It does **not** verify the COSE_Sign1 signature. The embedded hash is only trustworthy once the signature has been verified, so you **must** cryptographically verify the signature and establish trust in the signer **before** calling `SignatureMatches(...)`. A `true` result from an unverified message is meaningless, because the embedded hash would itself be attacker-controllable.
+>
+> For end-to-end validation (signature + trust + indirect content), prefer `CoseHandler.Validate(...)`, which verifies the signature first and only then compares the indirect content hash. Call `SignatureMatches(...)` directly only when you have already verified the signature and established trust through some other path (for example `VerifyEmbedded`/`VerifyDetached` together with a trust decision).
+>
+> A clearer alias, `ContentDigestMatches(...)`, is provided with the same `Stream`/`Byte[]` shapes and identical behavior &mdash; the name avoids overloading "Signature" (which otherwise conflicts with the cryptographic COSE_Sign1 signature). Prefer `ContentDigestMatches(...)` in new code.
+
 #### Example:
 ```
 using CoseIndirectSignature.Extensions;
@@ -41,8 +48,20 @@ using System.IO;
 Stream coseFileStream = File.OpenRead(...);
 Stream originalContentStream = File.OpenRead(...);
 CoseSign1Message message = CoseMessage.DecodeSign1(coseFileStream);
+
+// REQUIRED: cryptographically verify the COSE_Sign1 signature and establish trust in the
+// signer BEFORE inspecting or comparing any value carried in the envelope. Replace the guard
+// below with your chosen verification path (for example CoseHandler.Validate(...), or
+// VerifyEmbedded/VerifyDetached with an appropriate trust decision). SignatureMatches(...) only
+// checks that the artifact hash equals the embedded hash; it does not verify the signature.
+if(!CallerVerifiedSignatureAndTrust(message))
+{
+   return false;
+}
+
 if(message.IsIndirectSignature())
 {
+   // Safe to compare now that the signature has been verified and the signer is trusted.
    return message.SignatureMatches(originalContentStream);
 }
 return false;


### PR DESCRIPTION
## What & why

`CoseSign1MessageIndirectSignatureExtensions.SignatureMatches(...)` compares the supplied artifact's
digest against the digest embedded in the COSE_Sign1 `.Content`. It is a **content-digest comparison**,
but the name and prior XML docs read as though it validates "the signature" — a **consumer-clarity /
documentation gap** (see #206). Verifying the COSE_Sign1 signature and establishing signer trust is a
separate step the caller is expected to perform, and `CoseHandler.Validate(...)` already does it
end-to-end.

This is a **V1 documentation + API-clarity** change. It intentionally does **not** couple
`CoseIndirectSignature` to certificate/trust verification; that separation of concerns is preserved.

## Changes

- **Docs (XML):** class-level remark + both `SignatureMatches(...)` overloads now state that this is a
  content-digest comparison and that callers are expected to verify the signature/trust first. Corrected
  the misleading "matches the signature of the artifact" wording.
- **New alias:** `ContentDigestMatches(Stream)` and `ContentDigestMatches(ReadOnlyMemory<byte>)` — same
  shape, identical behavior, redirecting to `SignatureMatches(...)`. "Signature" is overloaded (COSE_Sign1
  signature vs. indirect content match); `ContentDigestMatches` makes the intent explicit and is the
  preferred name for new code.
- **Docs (markdown):** `docs/CoseIndirectSignature.md` gains a precondition callout, the example now
  verifies signature/trust before calling the matcher, and `ContentDigestMatches` is introduced.
- **Tests:** added parity tests (stream/bytes, success/failure, null) confirming `ContentDigestMatches`
  agrees with `SignatureMatches`.

## Why only V1 / `main`

V2 (`CoseSign1.Validation.CoseSign1Validator` + `IndirectSignatureValidator : IPostSignatureValidator`)
and the native Rust validation pipeline already express this consumption contract structurally: both run
indirect content matching as a post-signature step (after signature verification). Since those branches
derive from `main`, this documentation change propagates to them on their next integration.

## Validation

- `dotnet build CoseIndirectSignature` → 0 warnings, 0 errors (`TreatWarningsAsErrors=true`).
- `dotnet test CoseIndirectSignature.Tests` → 107 passed, 0 failed.

Refs #206
